### PR TITLE
feat: support legacy pem keys

### DIFF
--- a/Berth/Core/SSH/PrivateKeyFormat.swift
+++ b/Berth/Core/SSH/PrivateKeyFormat.swift
@@ -1,0 +1,432 @@
+import CommonCrypto
+import Crypto
+import Foundation
+
+/// 历史私钥格式归一化。
+///
+/// Citadel 只认新版 OpenSSH 容器(`-----BEGIN OPENSSH PRIVATE KEY-----`,OpenSSH 6.5 引入、
+/// 7.8 起为 ssh-keygen 默认输出)。但用户手上大量私钥是老格式:
+///
+/// - PKCS#1(`-----BEGIN RSA PRIVATE KEY-----`):OpenSSH 7.8 之前生成的 key、`ssh-keygen -m PEM`、
+///   以及几乎所有云厂商(阿里云/腾讯云等)下发的 `.pem`
+/// - PKCS#8(`-----BEGIN PRIVATE KEY-----`):部分工具链导出的格式
+///
+/// 这里把它们解析出 RSA 参数后重新编码成 OpenSSH 容器,交回 Citadel 解析,
+/// 用户无需在命令行 `ssh-keygen -p` 转换自己的文件。
+enum PrivateKeyFormat {
+
+    /// 归一化结果
+    struct Normalized {
+        /// OpenSSH 容器格式的私钥文本
+        let text: String
+        /// 转换过程中已用 passphrase 解密(结果是明文密钥),调用方不应再把 passphrase 交给解析器
+        let passphraseConsumed: Bool
+        /// 是否发生了格式转换(原文即 OpenSSH 格式时为 false)
+        let converted: Bool
+    }
+
+    enum ConversionError: LocalizedError {
+        case notAPrivateKey
+        case publicKeyGiven
+        case unsupportedAlgorithm(String)
+        case encryptedPKCS8
+        case missingPassphrase
+        case wrongPassphrase
+        case unsupportedPEMCipher(String)
+        case malformedDER
+
+        var errorDescription: String? {
+            switch self {
+            case .notAPrivateKey:
+                return String(localized: "内容里没有找到私钥。请粘贴完整的私钥文件,包含 -----BEGIN ... PRIVATE KEY----- 首尾两行。")
+            case .publicKeyGiven:
+                return String(localized: "这是公钥(.pub),不能用于认证。请改用对应的私钥文件(去掉 .pub 后缀的那个)。")
+            case .unsupportedAlgorithm(let name):
+                return String(localized: "暂不支持 \(name) 密钥。Berth 支持 OpenSSH 格式的 ed25519,以及 OpenSSH / PKCS#1 / PKCS#8 格式的 RSA。")
+            case .encryptedPKCS8:
+                return String(localized: "这是加密的 PKCS#8 私钥,暂不支持直接导入。请先用 `ssh-keygen -p -f <文件>` 转成 OpenSSH 格式再导入。")
+            case .missingPassphrase:
+                return String(localized: "这把私钥有 passphrase,请在下方一并填写。")
+            case .wrongPassphrase:
+                return String(localized: "passphrase 不正确,无法解密这把私钥。")
+            case .unsupportedPEMCipher(let name):
+                return String(localized: "私钥用了不支持的加密算法 \(name)。请先用 `ssh-keygen -p -f <文件>` 转成 OpenSSH 格式再导入。")
+            case .malformedDER:
+                return String(localized: "私钥内容损坏或不完整,无法解析。")
+            }
+        }
+    }
+
+    /// 把任意受支持格式的私钥文本转成 OpenSSH 容器格式。
+    ///
+    /// 已是 OpenSSH 格式的原样返回(仅做换行规整,顺带修掉 CRLF 文件导致的解析失败)。
+    /// - Parameter comment: 转换时写入 OpenSSH 容器的注释字段,一般填密钥名
+    static func normalized(_ text: String, passphrase: String?, comment: String = "") throws -> Normalized {
+        guard let block = pemBlock(in: text) else {
+            if text.contains("ssh-rsa ") || text.contains("ssh-ed25519 ") || text.contains("ecdsa-sha2-") {
+                throw ConversionError.publicKeyGiven
+            }
+            throw ConversionError.notAPrivateKey
+        }
+
+        switch block.label {
+        case "OPENSSH PRIVATE KEY":
+            // Citadel 解析前会把 "\n" 全部删掉,但残留的 "\r" 会让首尾标记匹配失败
+            // (Windows 换行 / 从网页复制的文本),这里统一规整一遍。
+            return Normalized(text: block.canonicalText, passphraseConsumed: false, converted: false)
+
+        case "RSA PRIVATE KEY":
+            let der: Data
+            var consumed = false
+            if let dekInfo = block.headers["DEK-Info"] {
+                guard let passphrase, !passphrase.isEmpty else { throw ConversionError.missingPassphrase }
+                der = try decryptLegacyPEM(block.der, dekInfo: dekInfo, passphrase: passphrase)
+                consumed = true
+            } else {
+                der = block.der
+            }
+            let rsa: RSAComponents
+            do {
+                rsa = try parsePKCS1(der)
+            } catch {
+                // 口令错时 PKCS#7 去填充大概率会失败,但约 1/256 的概率会碰巧通过,
+                // 于是解出一堆乱码落到这里 —— 仍然是口令不对,别报"文件损坏"误导用户
+                throw consumed ? ConversionError.wrongPassphrase : error
+            }
+            return Normalized(
+                text: opensshContainer(rsa, comment: comment),
+                passphraseConsumed: consumed,
+                converted: true
+            )
+
+        case "PRIVATE KEY":
+            let rsa = try parsePKCS8(block.der)
+            return Normalized(
+                text: opensshContainer(rsa, comment: comment),
+                passphraseConsumed: false,
+                converted: true
+            )
+
+        case "ENCRYPTED PRIVATE KEY":
+            throw ConversionError.encryptedPKCS8
+
+        case "EC PRIVATE KEY":
+            throw ConversionError.unsupportedAlgorithm("ECDSA")
+
+        case "DSA PRIVATE KEY":
+            throw ConversionError.unsupportedAlgorithm("DSA")
+
+        default:
+            throw ConversionError.notAPrivateKey
+        }
+    }
+
+    // MARK: - PEM 拆解
+
+    private struct PEMBlock {
+        let label: String
+        let headers: [String: String]
+        let der: Data
+        /// 规整过换行的原始 PEM 文本
+        let canonicalText: String
+    }
+
+    private static func pemBlock(in text: String) -> PEMBlock? {
+        // 先统一换行:Swift 里 "\r\n" 是**单个** Character,直接按 "\n" 切会一刀都切不动,
+        // 整个 Windows 换行的文件会被当成一行。
+        let lines = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+        guard let beginIndex = lines.firstIndex(where: { $0.hasPrefix("-----BEGIN ") && $0.hasSuffix("-----") }),
+              let label = lines[beginIndex]
+                  .dropFirst("-----BEGIN ".count)
+                  .dropLast("-----".count)
+                  .trimmingCharacters(in: .whitespaces)
+                  .nonEmpty,
+              let endIndex = lines[beginIndex...].firstIndex(where: { $0.hasPrefix("-----END ") })
+        else { return nil }
+
+        var headers: [String: String] = [:]
+        var base64 = ""
+        var inHeaders = true
+        for line in lines[(beginIndex + 1)..<endIndex] {
+            if inHeaders {
+                if line.isEmpty { inHeaders = false; continue }
+                // RFC 1421 头部形如 "Proc-Type: 4,ENCRYPTED";base64 正文不含冒号
+                if let colon = line.firstIndex(of: ":") {
+                    let key = String(line[line.startIndex..<colon]).trimmingCharacters(in: .whitespaces)
+                    let value = String(line[line.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+                    headers[key] = value
+                    continue
+                }
+                inHeaders = false
+            }
+            base64 += line
+        }
+
+        let canonical = ([lines[beginIndex]] + lines[(beginIndex + 1)...endIndex].filter { !$0.isEmpty })
+            .joined(separator: "\n")
+
+        return PEMBlock(
+            label: label,
+            headers: headers,
+            der: Data(base64Encoded: base64) ?? Data(),
+            canonicalText: canonical
+        )
+    }
+
+    // MARK: - DER 解析
+
+    /// RSA 私钥参数(按 OpenSSH 线格式需要的字段;DER INTEGER 内容与 SSH mpint 编码规则一致,直接透传)
+    struct RSAComponents {
+        let modulus: [UInt8]          // n
+        let publicExponent: [UInt8]   // e
+        let privateExponent: [UInt8]  // d
+        let prime1: [UInt8]           // p
+        let prime2: [UInt8]           // q
+        let coefficient: [UInt8]      // iqmp = q^-1 mod p
+    }
+
+    /// PKCS#8 PrivateKeyInfo:SEQUENCE { version, AlgorithmIdentifier, OCTET STRING(内含 PKCS#1) }
+    static func parsePKCS8(_ der: Data) throws -> RSAComponents {
+        var outer = DERReader(der)
+        var body = DERReader(try outer.read(tag: .sequence))
+        _ = try body.read(tag: .integer)                       // version
+        var algorithm = DERReader(try body.read(tag: .sequence))
+        let oid = try algorithm.read(tag: .objectIdentifier)
+        guard oid == Self.rsaEncryptionOID else {
+            throw ConversionError.unsupportedAlgorithm(algorithmName(for: oid))
+        }
+        return try parsePKCS1(Data(try body.read(tag: .octetString)))
+    }
+
+    /// PKCS#1 RSAPrivateKey:SEQUENCE { version, n, e, d, p, q, exp1, exp2, iqmp }
+    static func parsePKCS1(_ der: Data) throws -> RSAComponents {
+        var outer = DERReader(der)
+        var body = DERReader(try outer.read(tag: .sequence))
+        let version = try body.read(tag: .integer)
+        // version 1 = multi-prime(三个以上素数),OpenSSH 线格式放不下,极罕见
+        guard version == [0x00] else { throw ConversionError.malformedDER }
+        let modulus = try body.read(tag: .integer)
+        let publicExponent = try body.read(tag: .integer)
+        let privateExponent = try body.read(tag: .integer)
+        let prime1 = try body.read(tag: .integer)
+        let prime2 = try body.read(tag: .integer)
+        _ = try body.read(tag: .integer)  // exponent1
+        _ = try body.read(tag: .integer)  // exponent2
+        let coefficient = try body.read(tag: .integer)
+        return RSAComponents(
+            modulus: modulus,
+            publicExponent: publicExponent,
+            privateExponent: privateExponent,
+            prime1: prime1,
+            prime2: prime2,
+            coefficient: coefficient
+        )
+    }
+
+    private static let rsaEncryptionOID: [UInt8] = [0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01]
+
+    private static func algorithmName(for oid: [UInt8]) -> String {
+        switch oid {
+        case [0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01]: return "ECDSA"
+        case [0x2B, 0x65, 0x70]: return String(localized: "PKCS#8 封装的 Ed25519")
+        case [0x2A, 0x86, 0x48, 0xCE, 0x38, 0x04, 0x01]: return "DSA"
+        default: return String(localized: "该类型")
+        }
+    }
+
+    struct DERReader {
+        enum Tag: UInt8 {
+            case integer = 0x02
+            case octetString = 0x04
+            case objectIdentifier = 0x06
+            case sequence = 0x30
+        }
+
+        private let bytes: [UInt8]
+        private var index = 0
+
+        init(_ data: Data) { bytes = [UInt8](data) }
+        init(_ bytes: [UInt8]) { self.bytes = bytes }
+
+        mutating func read(tag: Tag) throws -> [UInt8] {
+            guard index < bytes.count, bytes[index] == tag.rawValue else {
+                throw ConversionError.malformedDER
+            }
+            index += 1
+            let length = try readLength()
+            guard length >= 0, index + length <= bytes.count else { throw ConversionError.malformedDER }
+            defer { index += length }
+            return Array(bytes[index..<(index + length)])
+        }
+
+        private mutating func readLength() throws -> Int {
+            guard index < bytes.count else { throw ConversionError.malformedDER }
+            let first = bytes[index]
+            index += 1
+            guard first & 0x80 != 0 else { return Int(first) }
+            let count = Int(first & 0x7F)
+            // 4 字节足够表达任何现实中的密钥长度;0 是不定长(BER),DER 里不合法
+            guard count > 0, count <= 4, index + count <= bytes.count else {
+                throw ConversionError.malformedDER
+            }
+            var length = 0
+            for _ in 0..<count {
+                length = (length << 8) | Int(bytes[index])
+                index += 1
+            }
+            return length
+        }
+    }
+
+    // MARK: - 老式 PEM 解密(RFC 1421 + OpenSSL EVP_BytesToKey)
+
+    private static func decryptLegacyPEM(_ der: Data, dekInfo: String, passphrase: String) throws -> Data {
+        // DEK-Info: AES-128-CBC,3F2A...(IV 十六进制)
+        let parts = dekInfo.split(separator: ",", maxSplits: 1).map(String.init)
+        let cipherName = parts.first?.uppercased() ?? ""
+        guard parts.count == 2, let iv = hexBytes(parts[1]) else {
+            throw ConversionError.unsupportedPEMCipher(cipherName)
+        }
+
+        let algorithm: CCAlgorithm
+        let keyLength: Int
+        switch cipherName {
+        case "AES-128-CBC": algorithm = CCAlgorithm(kCCAlgorithmAES); keyLength = 16
+        case "AES-192-CBC": algorithm = CCAlgorithm(kCCAlgorithmAES); keyLength = 24
+        case "AES-256-CBC": algorithm = CCAlgorithm(kCCAlgorithmAES); keyLength = 32
+        case "DES-EDE3-CBC": algorithm = CCAlgorithm(kCCAlgorithm3DES); keyLength = 24
+        default: throw ConversionError.unsupportedPEMCipher(cipherName)
+        }
+
+        // OpenSSL 的 EVP_BytesToKey:MD5,1 轮,盐取 IV 前 8 字节
+        let salt = Array(iv.prefix(8))
+        var key: [UInt8] = []
+        var digest: [UInt8] = []
+        while key.count < keyLength {
+            var md5 = Insecure.MD5()
+            md5.update(data: digest)
+            md5.update(data: Data(passphrase.utf8))
+            md5.update(data: salt)
+            digest = Array(md5.finalize())
+            key += digest
+        }
+        key = Array(key.prefix(keyLength))
+
+        var output = [UInt8](repeating: 0, count: der.count + kCCBlockSizeAES128)
+        var moved = 0
+        let status = der.withUnsafeBytes { input in
+            CCCrypt(
+                CCOperation(kCCDecrypt),
+                algorithm,
+                CCOptions(kCCOptionPKCS7Padding),
+                key, key.count,
+                iv,
+                input.baseAddress, der.count,
+                &output, output.count,
+                &moved
+            )
+        }
+        // passphrase 不对时 PKCS#7 去填充几乎必然失败(kCCAlignmentError/kCCDecodeError)
+        guard status == CCCryptorStatus(kCCSuccess) else { throw ConversionError.wrongPassphrase }
+        return Data(output.prefix(moved))
+    }
+
+    private static func hexBytes(_ string: String) -> [UInt8]? {
+        let characters = Array(string.trimmingCharacters(in: .whitespaces))
+        guard characters.count % 2 == 0, !characters.isEmpty else { return nil }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(characters.count / 2)
+        for pair in stride(from: 0, to: characters.count, by: 2) {
+            guard let byte = UInt8(String(characters[pair...(pair + 1)]), radix: 16) else { return nil }
+            bytes.append(byte)
+        }
+        return bytes
+    }
+
+    // MARK: - OpenSSH 容器编码
+
+    /// 按 openssh-key-v1 布局重新编码(cipher/kdf 均为 none,即明文私钥)。
+    /// 参考 https://dnaeon.github.io/openssh-private-key-binary-format/
+    static func opensshContainer(_ rsa: RSAComponents, comment: String) -> String {
+        var publicBlob = Data()
+        publicBlob.appendSSHString(Data("ssh-rsa".utf8))
+        publicBlob.appendSSHMPInt(rsa.publicExponent)
+        publicBlob.appendSSHMPInt(rsa.modulus)
+
+        var privateBlob = Data()
+        // check1 == check2:解密成功的自校验字段
+        let check = UInt32.random(in: 0...UInt32.max)
+        privateBlob.appendSSHUInt32(check)
+        privateBlob.appendSSHUInt32(check)
+        privateBlob.appendSSHString(Data("ssh-rsa".utf8))
+        // 注意顺序与公钥块不同:私钥块是 n, e, d, iqmp, p, q
+        privateBlob.appendSSHMPInt(rsa.modulus)
+        privateBlob.appendSSHMPInt(rsa.publicExponent)
+        privateBlob.appendSSHMPInt(rsa.privateExponent)
+        privateBlob.appendSSHMPInt(rsa.coefficient)
+        privateBlob.appendSSHMPInt(rsa.prime1)
+        privateBlob.appendSSHMPInt(rsa.prime2)
+        privateBlob.appendSSHString(Data(comment.utf8))
+        // 填充到块大小(cipher none 时为 8),内容是 1,2,3…
+        var padding: UInt8 = 1
+        while privateBlob.count % 8 != 0 {
+            privateBlob.append(padding)
+            padding += 1
+        }
+
+        var blob = Data("openssh-key-v1".utf8)
+        blob.append(0x00)
+        blob.appendSSHString(Data("none".utf8))  // ciphername
+        blob.appendSSHString(Data("none".utf8))  // kdfname
+        blob.appendSSHString(Data())             // kdfoptions
+        blob.appendSSHUInt32(1)                  // 密钥数量
+        blob.appendSSHString(publicBlob)
+        blob.appendSSHString(privateBlob)
+
+        let base64 = blob.base64EncodedString()
+        let wrapped = stride(from: 0, to: base64.count, by: 70).map { offset -> String in
+            let start = base64.index(base64.startIndex, offsetBy: offset)
+            let end = base64.index(start, offsetBy: min(70, base64.count - offset))
+            return String(base64[start..<end])
+        }
+        return ([
+            "-----BEGIN OPENSSH PRIVATE KEY-----"
+        ] + wrapped + [
+            "-----END OPENSSH PRIVATE KEY-----"
+        ]).joined(separator: "\n")
+    }
+}
+
+private extension Data {
+    mutating func appendSSHUInt32(_ value: UInt32) {
+        var bigEndian = value.bigEndian
+        Swift.withUnsafeBytes(of: &bigEndian) { append(contentsOf: $0) }
+    }
+
+    mutating func appendSSHString(_ payload: Data) {
+        appendSSHUInt32(UInt32(payload.count))
+        append(payload)
+    }
+
+    /// SSH mpint:大端、最短编码、最高位为 1 时补前导 0x00(与 DER INTEGER 规则一致)
+    mutating func appendSSHMPInt(_ bytes: [UInt8]) {
+        var value = bytes
+        while value.count > 1 && value[0] == 0x00 && value[1] & 0x80 == 0 {
+            value.removeFirst()
+        }
+        if value == [0x00] { value = [] }
+        if let first = value.first, first & 0x80 != 0 {
+            value.insert(0x00, at: 0)
+        }
+        appendSSHString(Data(value))
+    }
+}
+
+private extension String {
+    var nonEmpty: String? { isEmpty ? nil : self }
+}

--- a/Berth/Core/SSH/TerminalSession.swift
+++ b/Berth/Core/SSH/TerminalSession.swift
@@ -1002,11 +1002,16 @@ final class TerminalSession: Identifiable {
     }
 
     private static func keyAuthentication(username: String, keyText: String, passphrase: String?) throws -> SSHAuthenticationMethod {
-        let decryptionKey = passphrase.flatMap { $0.isEmpty ? nil : Data($0.utf8) }
-        if let key = try? Curve25519.Signing.PrivateKey(sshEd25519: keyText, decryptionKey: decryptionKey) {
+        // 磁盘上的私钥文件常是老式 PKCS#1/PKCS#8 PEM(~/.ssh/id_rsa、云厂商 .pem),
+        // 先归一化成 OpenSSH 容器再交给 Citadel。文件本身不动。
+        let normalized = try PrivateKeyFormat.normalized(keyText, passphrase: passphrase)
+        let decryptionKey = normalized.passphraseConsumed
+            ? nil
+            : passphrase.flatMap { $0.isEmpty ? nil : Data($0.utf8) }
+        if let key = try? Curve25519.Signing.PrivateKey(sshEd25519: normalized.text, decryptionKey: decryptionKey) {
             return .ed25519(username: username, privateKey: key)
         }
-        if let key = try? Insecure.RSA.PrivateKey(sshRsa: keyText, decryptionKey: decryptionKey) {
+        if let key = try? Insecure.RSA.PrivateKey(sshRsa: normalized.text, decryptionKey: decryptionKey) {
             return .rsa(username: username, privateKey: key)
         }
         throw SessionError.unsupportedKey

--- a/Berth/Core/Services/KeyStore.swift
+++ b/Berth/Core/Services/KeyStore.swift
@@ -15,7 +15,7 @@ enum KeyStore {
         var errorDescription: String? {
             switch self {
             case .unsupportedKey:
-                return String(localized: "无法解析密钥:支持 OpenSSH 格式的 ed25519 / RSA 私钥;若有 passphrase 请一并填写。")
+                return String(localized: "无法解析密钥:支持 ed25519 与 RSA 私钥(OpenSSH、PKCS#1、PKCS#8 格式);若有 passphrase 请一并填写。")
             case .emptyName:
                 return String(localized: "给密钥起个名字。")
             }
@@ -45,15 +45,23 @@ enum KeyStore {
     static func importKey(name: String, pemText: String, passphrase: String?, context: ModelContext) throws -> SSHKeyRecord {
         let trimmedName = name.trimmingCharacters(in: .whitespaces)
         guard !trimmedName.isEmpty else { throw KeyStoreError.emptyName }
-        let decryptionKey = passphrase.flatMap { $0.isEmpty ? nil : Data($0.utf8) }
+
+        // 老式 PKCS#1 / PKCS#8 PEM(云厂商下发的 .pem、OpenSSH 7.8 之前生成的 key)
+        // 先转成 OpenSSH 容器 —— Citadel 只认后者。转换失败会抛出带排查提示的错误。
+        let normalized = try PrivateKeyFormat.normalized(pemText, passphrase: passphrase, comment: trimmedName)
+        let material = normalized.text
+        // 转换时若已用 passphrase 解密,得到的就是明文密钥,不能再交给解析器当解密口令
+        let decryptionKey = normalized.passphraseConsumed
+            ? nil
+            : passphrase.flatMap { $0.isEmpty ? nil : Data($0.utf8) }
 
         let keyType: String
         let publicLine: String
 
-        if let key = try? Curve25519.Signing.PrivateKey(sshEd25519: pemText, decryptionKey: decryptionKey) {
+        if let key = try? Curve25519.Signing.PrivateKey(sshEd25519: material, decryptionKey: decryptionKey) {
             keyType = "ssh-ed25519"
             publicLine = OpenSSHFormat.publicKeyLine(ed25519: key.publicKey, comment: trimmedName)
-        } else if let key = try? Insecure.RSA.PrivateKey(sshRsa: pemText, decryptionKey: decryptionKey) {
+        } else if let key = try? Insecure.RSA.PrivateKey(sshRsa: material, decryptionKey: decryptionKey) {
             keyType = "ssh-rsa"
             var body = ByteBufferAllocator().buffer(capacity: 1024)
             _ = key.publicKey.write(to: &body)
@@ -67,8 +75,9 @@ enum KeyStore {
         }
 
         let record = SSHKeyRecord(name: trimmedName, keyType: keyType, publicKey: publicLine, storageFormat: .opensshPEM)
-        try KeychainStore.save(pemText, account: KeychainStore.privateKeyAccount(for: record.id))
-        if let passphrase, !passphrase.isEmpty {
+        try KeychainStore.save(material, account: KeychainStore.privateKeyAccount(for: record.id))
+        // passphrase 已在转换时用掉的话,库里存的是明文密钥,没有再存口令的必要
+        if let passphrase, !passphrase.isEmpty, !normalized.passphraseConsumed {
             try KeychainStore.save(passphrase, account: KeychainStore.keyPassphraseAccount(for: record.id))
         }
         context.insert(record)

--- a/Berth/Resources/Localizable.xcstrings
+++ b/Berth/Resources/Localizable.xcstrings
@@ -625,6 +625,16 @@
         }
       }
     },
+	"PKCS#8 封装的 Ed25519": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PKCS#8-wrapped Ed25519"
+          }
+        }
+      }
+    },
     "Passphrase": {
       "localizations": {
         "en": {
@@ -904,6 +914,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "The iOS version doesn't support “%@” authentication yet"
+          }
+        }
+      }
+    },
+    "passphrase 不正确,无法解密这把私钥。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incorrect passphrase — the private key could not be decrypted."
           }
         }
       }
@@ -1902,6 +1922,16 @@
         }
       }
     },
+    "内容里没有找到私钥。请粘贴完整的私钥文件,包含 -----BEGIN ... PRIVATE KEY----- 首尾两行。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No private key found in the content. Paste the whole private key file, including the -----BEGIN ... PRIVATE KEY----- and END lines."
+          }
+        }
+      }
+    },
     "内核": {
       "localizations": {
         "en": {
@@ -1943,6 +1973,7 @@
       }
     },
     "分组": {
+      "extractionState": "stale",
       "localizations": {
         "en": {
           "stringUnit": {
@@ -3723,6 +3754,7 @@
       }
     },
     "无分组": {
+      "extractionState": "stale",
       "localizations": {
         "en": {
           "stringUnit": {
@@ -3772,12 +3804,12 @@
         }
       }
     },
-    "无法解析密钥:支持 OpenSSH 格式的 ed25519 / RSA 私钥;若有 passphrase 请一并填写。": {
+    "无法解析密钥:支持 ed25519 与 RSA 私钥(OpenSSH、PKCS#1、PKCS#8 格式);若有 passphrase 请一并填写。": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Unable to parse the key: OpenSSH-format ed25519 / RSA private keys are supported; include the passphrase if it has one."
+            "value": "Unable to parse the key: ed25519 and RSA private keys are supported (OpenSSH, PKCS#1 and PKCS#8 formats); include the passphrase if it has one."
           }
         }
       }
@@ -4762,6 +4794,16 @@
         }
       }
     },
+    "私钥内容损坏或不完整,无法解析。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The private key is corrupted or incomplete and cannot be parsed."
+          }
+        }
+      }
+    },
     "私钥只保存在 macOS Keychain 中,不写入磁盘文件。": {
       "localizations": {
         "en": {
@@ -4778,6 +4820,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "Private key file"
+          }
+        }
+      }
+    },
+    "私钥用了不支持的加密算法 %@。请先用 `ssh-keygen -p -f <文件>` 转成 OpenSSH 格式再导入。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The private key uses an unsupported cipher (%@). Convert it to OpenSSH format first with `ssh-keygen -p -f <file>`, then import."
           }
         }
       }
@@ -5468,6 +5520,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "This tab has active SSH connections (possibly multiple panes)."
+          }
+        }
+      }
+    },
+    "该类型": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "this type"
           }
         }
       }

--- a/BerthTests/PrivateKeyFormatTests.swift
+++ b/BerthTests/PrivateKeyFormatTests.swift
@@ -1,0 +1,177 @@
+import Citadel
+import Crypto
+import NIOCore
+import XCTest
+@testable import Berth
+
+/// 老式 PEM 私钥归一化。fixture 用 ssh-keygen 现场生成,不把密钥材料提交进仓库。
+final class PrivateKeyFormatTests: XCTestCase {
+
+    // MARK: - 转换正确性
+
+    func testConvertsPKCS1ToOpenSSH() throws {
+        let key = try GeneratedKey(mode: "PEM")
+        let normalized = try PrivateKeyFormat.normalized(key.privateText, passphrase: nil, comment: "test")
+
+        XCTAssertTrue(normalized.converted)
+        XCTAssertFalse(normalized.passphraseConsumed)
+        XCTAssertTrue(normalized.text.hasPrefix("-----BEGIN OPENSSH PRIVATE KEY-----"))
+        // 转换结果必须能被 Citadel 解出来,且公钥与 ssh-keygen 生成的 .pub 一致
+        XCTAssertEqual(try publicBlob(ofRSA: normalized.text), key.publicBlob)
+    }
+
+    func testConvertsPKCS8ToOpenSSH() throws {
+        let key = try GeneratedKey(mode: "PKCS8")
+        let normalized = try PrivateKeyFormat.normalized(key.privateText, passphrase: nil, comment: "test")
+
+        XCTAssertTrue(normalized.converted)
+        XCTAssertEqual(try publicBlob(ofRSA: normalized.text), key.publicBlob)
+    }
+
+    func testConvertsEncryptedPKCS1() throws {
+        let key = try GeneratedKey(mode: "PEM", passphrase: "berth-spike")
+        let normalized = try PrivateKeyFormat.normalized(
+            key.privateText, passphrase: "berth-spike", comment: "test"
+        )
+
+        // 解密后存的是明文密钥,调用方不应再把 passphrase 当解密口令传下去
+        XCTAssertTrue(normalized.passphraseConsumed)
+        XCTAssertEqual(try publicBlob(ofRSA: normalized.text), key.publicBlob)
+    }
+
+    func testEncryptedPKCS1RejectsWrongPassphrase() throws {
+        let key = try GeneratedKey(mode: "PEM", passphrase: "berth-spike")
+        XCTAssertThrowsError(
+            try PrivateKeyFormat.normalized(key.privateText, passphrase: "wrong", comment: "")
+        ) { error in
+            XCTAssertEqual(error as? PrivateKeyFormat.ConversionError, .wrongPassphrase)
+        }
+    }
+
+    func testEncryptedPKCS1RequiresPassphrase() throws {
+        let key = try GeneratedKey(mode: "PEM", passphrase: "berth-spike")
+        XCTAssertThrowsError(
+            try PrivateKeyFormat.normalized(key.privateText, passphrase: nil, comment: "")
+        ) { error in
+            XCTAssertEqual(error as? PrivateKeyFormat.ConversionError, .missingPassphrase)
+        }
+    }
+
+    // MARK: - 已是 OpenSSH 格式:原样通过
+
+    func testPassesThroughOpenSSHRSA() throws {
+        let key = try GeneratedKey(mode: nil)
+        let normalized = try PrivateKeyFormat.normalized(key.privateText, passphrase: nil, comment: "")
+
+        XCTAssertFalse(normalized.converted)
+        XCTAssertEqual(try publicBlob(ofRSA: normalized.text), key.publicBlob)
+    }
+
+    func testPassesThroughOpenSSHEd25519() throws {
+        let key = try GeneratedKey(mode: nil, type: "ed25519")
+        let normalized = try PrivateKeyFormat.normalized(key.privateText, passphrase: nil, comment: "")
+
+        XCTAssertFalse(normalized.converted)
+        XCTAssertNoThrow(try Curve25519.Signing.PrivateKey(sshEd25519: normalized.text))
+    }
+
+    /// Citadel 解析前只删 "\n",残留的 "\r" 会让首尾标记匹配失败 —— 归一化顺手修掉
+    func testRepairsCRLFLineEndings() throws {
+        let key = try GeneratedKey(mode: nil)
+        let crlf = key.privateText.replacingOccurrences(of: "\n", with: "\r\n") + "\r\n"
+
+        XCTAssertThrowsError(try Insecure.RSA.PrivateKey(sshRsa: crlf), "前提:Citadel 直接吃 CRLF 会失败")
+        let normalized = try PrivateKeyFormat.normalized(crlf, passphrase: nil, comment: "")
+        XCTAssertEqual(try publicBlob(ofRSA: normalized.text), key.publicBlob)
+    }
+
+    // MARK: - 错误提示
+
+    func testRejectsECDSAWithNamedError() throws {
+        let key = try GeneratedKey(mode: "PEM", type: "ecdsa")
+        XCTAssertThrowsError(try PrivateKeyFormat.normalized(key.privateText, passphrase: nil)) { error in
+            XCTAssertEqual(error as? PrivateKeyFormat.ConversionError, .unsupportedAlgorithm("ECDSA"))
+        }
+    }
+
+    func testRejectsPublicKeyWithNamedError() throws {
+        let key = try GeneratedKey(mode: nil)
+        XCTAssertThrowsError(try PrivateKeyFormat.normalized(key.publicLine, passphrase: nil)) { error in
+            XCTAssertEqual(error as? PrivateKeyFormat.ConversionError, .publicKeyGiven)
+        }
+    }
+
+    func testRejectsGarbage() {
+        XCTAssertThrowsError(try PrivateKeyFormat.normalized("hello world", passphrase: nil)) { error in
+            XCTAssertEqual(error as? PrivateKeyFormat.ConversionError, .notAPrivateKey)
+        }
+    }
+
+    func testRejectsTruncatedPEM() throws {
+        let key = try GeneratedKey(mode: "PEM")
+        var lines = key.privateText.split(separator: "\n").map(String.init)
+        lines.removeSubrange(3..<10)  // 砍掉一段 base64,保留首尾标记
+        XCTAssertThrowsError(
+            try PrivateKeyFormat.normalized(lines.joined(separator: "\n"), passphrase: nil)
+        ) { error in
+            XCTAssertEqual(error as? PrivateKeyFormat.ConversionError, .malformedDER)
+        }
+    }
+
+    // MARK: - 辅助
+
+    /// 从 OpenSSH 格式文本解出 RSA 私钥,回写公钥 blob(e‖n)用于和 .pub 比对
+    private func publicBlob(ofRSA text: String) throws -> Data {
+        let key = try Insecure.RSA.PrivateKey(sshRsa: text)
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        _ = key.publicKey.write(to: &buffer)
+        return Data(buffer.readableBytesView)
+    }
+
+    /// 用 ssh-keygen 在临时目录生成一把密钥
+    private struct GeneratedKey {
+        let privateText: String
+        let publicLine: String
+        /// .pub 里 base64 解出来的 blob,去掉开头的 "ssh-rsa" 类型串,只留 e‖n
+        let publicBlob: Data
+
+        init(mode: String?, type: String = "rsa", passphrase: String = "") throws {
+            let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("berth-keytest-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directory) }
+
+            let path = directory.appendingPathComponent("id").path
+            var arguments = ["-t", type, "-N", passphrase, "-C", "berth-test", "-q", "-f", path]
+            if type == "rsa" { arguments += ["-b", "2048"] }
+            if let mode { arguments += ["-m", mode] }
+
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh-keygen")
+            process.arguments = arguments
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else {
+                throw XCTSkip("ssh-keygen 生成 \(type)/\(mode ?? "openssh") 失败")
+            }
+
+            privateText = try String(contentsOfFile: path, encoding: .utf8)
+            publicLine = try String(contentsOfFile: path + ".pub", encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            let fields = publicLine.split(separator: " ")
+            let blob = try XCTUnwrap(Data(base64Encoded: String(fields[1])))
+            // blob = string(keytype) ‖ e ‖ n,去掉首个 SSH string 后与 Citadel 的 write(to:) 对齐
+            let typeLength = Int(blob.prefix(4).reduce(UInt32(0)) { $0 << 8 | UInt32($1) })
+            publicBlob = blob.dropFirst(4 + typeLength)
+        }
+    }
+}
+
+extension PrivateKeyFormat.ConversionError: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        String(describing: lhs) == String(describing: rhs)
+    }
+}

--- a/BerthiOS/IOSTerminalSession.swift
+++ b/BerthiOS/IOSTerminalSession.swift
@@ -339,11 +339,15 @@ final class IOSTerminalSession {
                 return .ed25519(username: hop.username, privateKey: key)
             }
             let passphrase = try KeychainStore.read(account: KeychainStore.keyPassphraseAccount(for: keyID))
-            let decryptionKey = passphrase.flatMap { $0.isEmpty ? nil : Data($0.utf8) }
-            if let key = try? Curve25519.Signing.PrivateKey(sshEd25519: material, decryptionKey: decryptionKey) {
+            // 同步过来的密钥可能是在 Mac 上以老式 PEM 存入的,统一先归一化
+            let normalized = try PrivateKeyFormat.normalized(material, passphrase: passphrase)
+            let decryptionKey = normalized.passphraseConsumed
+                ? nil
+                : passphrase.flatMap { $0.isEmpty ? nil : Data($0.utf8) }
+            if let key = try? Curve25519.Signing.PrivateKey(sshEd25519: normalized.text, decryptionKey: decryptionKey) {
                 return .ed25519(username: hop.username, privateKey: key)
             }
-            if let key = try? Insecure.RSA.PrivateKey(sshRsa: material, decryptionKey: decryptionKey) {
+            if let key = try? Insecure.RSA.PrivateKey(sshRsa: normalized.text, decryptionKey: decryptionKey) {
                 return .rsa(username: hop.username, privateKey: key)
             }
             throw IOSSessionError.unsupportedKey

--- a/project.yml
+++ b/project.yml
@@ -90,6 +90,7 @@ targets:
       - path: Berth/Core/SSH/KnownHostsStore.swift
       - path: Berth/Core/SSH/HostKeyValidation.swift
       - path: Berth/Core/SSH/OpenSSHFormat.swift
+      - path: Berth/Core/SSH/PrivateKeyFormat.swift
       - path: Berth/Core/SSH/SSHConnection.swift
       - path: Berth/Core/SSH/PortForwardService.swift
       - path: Berth/Core/SSH/ProxyConnector.swift


### PR DESCRIPTION
历史私钥格式归一化。

Citadel 只认新版 OpenSSH 容器(`-----BEGIN OPENSSH PRIVATE KEY-----`,OpenSSH 6.5 引入、
7.8 起为 ssh-keygen 默认输出)。但用户手上大量私钥是老格式:

- PKCS#1(`-----BEGIN RSA PRIVATE KEY-----`):OpenSSH 7.8 之前生成的 key、`ssh-keygen -m PEM`、
  以及几乎所有云厂商(阿里云/腾讯云等)下发的 `.pem`
- PKCS#8(`-----BEGIN PRIVATE KEY-----`):部分工具链导出的格式

这个改动把它们解析出 RSA 参数后重新编码成 OpenSSH 容器,交回 Citadel 解析,
用户无需在命令行 `ssh-keygen -p` 转换自己的文件。