### PR TITLE
加入 SSH Config 中的常见 Include 指令支持

### DIFF
--- a/Berth/Core/Parsing/SSHConfigParser.swift
+++ b/Berth/Core/Parsing/SSHConfigParser.swift
@@ -67,9 +67,6 @@ struct SSHConfigParseResult {
 /// ssh_config 解析器。支持 Host 多别名与通配(*、?、! 取反)、
 /// HostName / User / Port / IdentityFile(~ 展开)/ ProxyJump,
 /// 参数语义与 ssh 一致:每个参数取「第一次出现」的值。
-/// ssh_config 解析器。支持 Host 多别名与通配(*、?、! 取反)、
-/// HostName / User / Port / IdentityFile(~ 展开)/ ProxyJump,
-/// 参数语义与 ssh 一致:每个参数取「第一次出现」的值。
 /// - Match 块:仍未支持,跳过并在 `SSHConfigIssue` 中报告。
 /// - Include 指令:纯文本 parser (`parse` / `parseDetailed`) 不访问文件系统、不展开 Include;
 ///   文件 parser (`parseFile` / `parseFileDetailed`) 支持展开首个 Host/Match 之前的常见顶层 Include

--- a/Berth/Core/Parsing/SSHConfigParser.swift
+++ b/Berth/Core/Parsing/SSHConfigParser.swift
@@ -67,7 +67,13 @@ struct SSHConfigParseResult {
 /// ssh_config 解析器。支持 Host 多别名与通配(*、?、! 取反)、
 /// HostName / User / Port / IdentityFile(~ 展开)/ ProxyJump,
 /// 参数语义与 ssh 一致:每个参数取「第一次出现」的值。
-/// Match 块与 Include 指令暂不支持 —— 跳过,并记进 `SSHConfigIssue` 由 UI 告知用户。
+/// ssh_config 解析器。支持 Host 多别名与通配(*、?、! 取反)、
+/// HostName / User / Port / IdentityFile(~ 展开)/ ProxyJump,
+/// 参数语义与 ssh 一致:每个参数取「第一次出现」的值。
+/// - Match 块:仍未支持,跳过并在 `SSHConfigIssue` 中报告。
+/// - Include 指令:纯文本 parser (`parse` / `parseDetailed`) 不访问文件系统、不展开 Include;
+///   文件 parser (`parseFile` / `parseFileDetailed`) 支持展开首个 Host/Match 之前的常见顶层 Include
+///   (如 `~/.ssh/conf.d/*.conf` 或绝对路径单文件),其它 Include 继续在 `SSHConfigIssue` 中报告。
 enum SSHConfigParser {
 
     struct Block {
@@ -137,28 +143,154 @@ enum SSHConfigParser {
         return SSHConfigParseResult(hosts: hosts, issues: deduped)
     }
 
-    static func parseFile(at path: String) -> [SSHConfigHost] {
-        parseFileDetailed(at: path).hosts
+    static func parseFile(at path: String, homeDirectory: String = NSHomeDirectory()) -> [SSHConfigHost] {
+        parseFileDetailed(at: path, homeDirectory: homeDirectory).hosts
     }
 
     /// 文件不存在不算问题(还没写过 config 的新用户),返回空结果
-    static func parseFileDetailed(at path: String) -> SSHConfigParseResult {
-        guard FileManager.default.fileExists(atPath: path) else { return SSHConfigParseResult() }
+    static func parseFileDetailed(at path: String, homeDirectory: String = NSHomeDirectory()) -> SSHConfigParseResult {
+        let resolvedPath = expandTilde(path, home: homeDirectory)
+        guard FileManager.default.fileExists(atPath: resolvedPath) else { return SSHConfigParseResult() }
+        let rawContent: String
         do {
-            return parseDetailed(try String(contentsOfFile: path, encoding: .utf8))
+            rawContent = try String(contentsOfFile: resolvedPath, encoding: .utf8)
         } catch {
             // 不是 UTF-8:让系统猜一次编码,再不行才作为问题上报
             var encoding = String.Encoding.utf8
-            if let text = try? String(contentsOfFile: path, usedEncoding: &encoding) {
-                return parseDetailed(text)
+            if let text = try? String(contentsOfFile: resolvedPath, usedEncoding: &encoding) {
+                rawContent = text
+            } else {
+                return SSHConfigParseResult(
+                    issues: [SSHConfigIssue(kind: .unreadable(error.localizedDescription), line: nil)]
+                )
             }
-            return SSHConfigParseResult(
-                issues: [SSHConfigIssue(kind: .unreadable(error.localizedDescription), line: nil)]
-            )
         }
+
+        let (preprocessedText, initialIssues) = preprocessTopLevelIncludes(in: rawContent, homeDirectory: homeDirectory)
+        var result = parseDetailed(preprocessedText, homeDirectory: homeDirectory)
+        if !initialIssues.isEmpty {
+            var allIssues = initialIssues
+            for issue in result.issues where !allIssues.contains(issue) {
+                allIssues.append(issue)
+            }
+            result.issues = allIssues
+        }
+        return result
     }
 
     // MARK: - 内部
+
+    /// 在文件导入路径中,展开首个有效 Host / Match 之前出现的顶层 Include 指令。
+    /// 纯文本 parseDetailed 不调用此方法,保持纯函数且不访问文件系统。
+    private static func preprocessTopLevelIncludes(
+        in text: String,
+        homeDirectory: String
+    ) -> (text: String, initialIssues: [SSHConfigIssue]) {
+        var outputLines: [String] = []
+        var initialIssues: [SSHConfigIssue] = []
+        var seenHostOrMatch = false
+
+        for rawLine in text.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty, !line.hasPrefix("#") else {
+                outputLines.append(rawLine)
+                continue
+            }
+
+            let (key, value) = splitKeyValue(line)
+            if key == "host" || key == "match" {
+                seenHostOrMatch = true
+                outputLines.append(rawLine)
+                continue
+            }
+
+            if !seenHostOrMatch && key == "include" {
+                if let includedContents = resolveInclude(value: value, homeDirectory: homeDirectory, issues: &initialIssues) {
+                    outputLines.append(includedContents)
+                } else {
+                    // 无法展开或不在支持范围内,保留原 Include 行由后续 parseDetailed 记录 issue
+                    outputLines.append(rawLine)
+                }
+            } else {
+                outputLines.append(rawLine)
+            }
+        }
+
+        return (outputLines.joined(separator: "\n"), initialIssues)
+    }
+
+    private static func resolveInclude(
+        value: String,
+        homeDirectory: String,
+        issues: inout [SSHConfigIssue]
+    ) -> String? {
+        let expandedPath = expandTilde(value, home: homeDirectory)
+
+        // 仅支持绝对路径(含 ~ 展开后)
+        guard expandedPath.hasPrefix("/") else { return nil }
+
+        if expandedPath.contains("*") {
+            // Glob 模式:仅支持 *.conf 形式的文件匹配
+            let dirPath = (expandedPath as NSString).deletingLastPathComponent
+            let pattern = (expandedPath as NSString).lastPathComponent
+
+            // 目录路径本身不得含通配符,文件名通配须为 *.conf
+            guard !dirPath.contains("*") && !dirPath.contains("?") else { return nil }
+
+            var isDir: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: dirPath, isDirectory: &isDir), isDir.boolValue else {
+                return nil
+            }
+
+            guard let entries = try? FileManager.default.contentsOfDirectory(atPath: dirPath) else {
+                return nil
+            }
+
+            let matchedEntries = entries.filter { entry in
+                guard !entry.hasPrefix(".") else { return false }
+                guard entry.hasSuffix(".conf") else { return false }
+                guard wildcardMatch(entry, pattern: pattern) else { return false }
+                let fullPath = (dirPath as NSString).appendingPathComponent(entry)
+                var itemIsDir: ObjCBool = false
+                guard FileManager.default.fileExists(atPath: fullPath, isDirectory: &itemIsDir), !itemIsDir.boolValue else {
+                    return false
+                }
+                return true
+            }.sorted()
+
+            guard !matchedEntries.isEmpty else { return nil }
+
+            var contents: [String] = []
+            for entry in matchedEntries {
+                let fullPath = (dirPath as NSString).appendingPathComponent(entry)
+                if let fileContent = readFileContent(at: fullPath, issues: &issues) {
+                    contents.append(fileContent)
+                }
+            }
+            guard !contents.isEmpty else { return nil }
+            return contents.joined(separator: "\n")
+        } else {
+            // 单个绝对路径文件
+            var isDir: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: expandedPath, isDirectory: &isDir), !isDir.boolValue else {
+                return nil
+            }
+            return readFileContent(at: expandedPath, issues: &issues)
+        }
+    }
+
+    private static func readFileContent(at path: String, issues: inout [SSHConfigIssue]) -> String? {
+        do {
+            return try String(contentsOfFile: path, encoding: .utf8)
+        } catch {
+            var encoding = String.Encoding.utf8
+            if let text = try? String(contentsOfFile: path, usedEncoding: &encoding) {
+                return text
+            }
+            issues.append(SSHConfigIssue(kind: .unreadable("\(path): \(error.localizedDescription)"), line: nil))
+            return nil
+        }
+    }
 
     private static func parseBlocks(_ text: String, issues: inout [SSHConfigIssue]) -> [Block] {
         var blocks: [Block] = []
@@ -279,9 +411,10 @@ enum SSHConfigParser {
 
     private static func expandTilde(_ path: String, home: String) -> String {
         guard path.hasPrefix("~") else { return path }
-        if path == "~" { return home }
+        let trimmedHome = home.hasSuffix("/") ? String(home.dropLast()) : home
+        if path == "~" { return trimmedHome }
         if path.hasPrefix("~/") {
-            return home + String(path.dropFirst(1))
+            return trimmedHome + String(path.dropFirst(1))
         }
         return path
     }

--- a/BerthTests/SSHConfigParserTests.swift
+++ b/BerthTests/SSHConfigParserTests.swift
@@ -232,6 +232,207 @@ final class SSHConfigParserTests: XCTestCase {
         """
         XCTAssertTrue(SSHConfigParser.parseDetailed(config).issues.isEmpty)
     }
+
+    // MARK: - Include 指令测试
+
+    private func createTempDirectory() throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BerthTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        return tempDir
+    }
+
+    /// Test A: ~/.ssh/conf.d/*.conf 通配与 ~ 展开
+    func testIncludeTildeGlobConf() throws {
+        let tempHome = try createTempDirectory()
+        let sshDir = tempHome.appendingPathComponent(".ssh")
+        let confD = sshDir.appendingPathComponent("conf.d")
+        try FileManager.default.createDirectory(at: confD, withIntermediateDirectories: true)
+
+        let rootConfig = "Include ~/.ssh/conf.d/*.conf\n"
+        let configFile = sshDir.appendingPathComponent("config")
+        try rootConfig.write(to: configFile, atomically: true, encoding: .utf8)
+
+        let conf1 = """
+        Host 10-home
+            HostName home.example.com
+            User dev
+            Port 2201
+        """
+        try conf1.write(to: confD.appendingPathComponent("10-home.conf"), atomically: true, encoding: .utf8)
+
+        let conf2 = """
+        Host 20-work
+            HostName work.example.com
+            User workuser
+            Port 2202
+        """
+        try conf2.write(to: confD.appendingPathComponent("20-work.conf"), atomically: true, encoding: .utf8)
+
+        let result = SSHConfigParser.parseFileDetailed(at: configFile.path, homeDirectory: tempHome.path)
+        XCTAssertEqual(result.hosts.map(\.alias), ["10-home", "20-work"])
+        XCTAssertEqual(result.hosts[0].hostname, "home.example.com")
+        XCTAssertEqual(result.hosts[0].user, "dev")
+        XCTAssertEqual(result.hosts[0].port, 2201)
+        XCTAssertEqual(result.hosts[1].hostname, "work.example.com")
+        XCTAssertEqual(result.hosts[1].user, "workuser")
+        XCTAssertEqual(result.hosts[1].port, 2202)
+        XCTAssertFalse(result.issues.contains { issue in
+            if case .includeNotExpanded = issue.kind { return true }
+            return false
+        })
+    }
+
+    /// Test B: 绝对路径单文件 Include
+    func testIncludeAbsolutePathSingleFile() throws {
+        let tempDir = try createTempDirectory()
+        let workConf = tempDir.appendingPathComponent("work.conf")
+        let workContent = """
+        Host work
+            HostName work.example.com
+            User workuser
+            Port 2222
+        """
+        try workContent.write(to: workConf, atomically: true, encoding: .utf8)
+
+        let rootConf = tempDir.appendingPathComponent("root.conf")
+        let rootContent = "Include \(workConf.path)\n"
+        try rootContent.write(to: rootConf, atomically: true, encoding: .utf8)
+
+        let result = SSHConfigParser.parseFileDetailed(at: rootConf.path, homeDirectory: tempDir.path)
+        XCTAssertEqual(result.hosts.map(\.alias), ["work"])
+        XCTAssertEqual(result.hosts[0].hostname, "work.example.com")
+        XCTAssertEqual(result.hosts[0].user, "workuser")
+        XCTAssertEqual(result.hosts[0].port, 2222)
+        XCTAssertTrue(result.issues.isEmpty)
+    }
+
+    /// Test C: glob 字典序与 first-obtained-value 生效
+    func testIncludeGlobLexicalOrderAndFirstObtainedValue() throws {
+        let tempHome = try createTempDirectory()
+        let confD = tempHome.appendingPathComponent(".ssh/conf.d")
+        try FileManager.default.createDirectory(at: confD, withIntermediateDirectories: true)
+
+        let file20 = """
+        Host web
+            HostName second.example.com
+            User second
+        """
+        try file20.write(to: confD.appendingPathComponent("20-second.conf"), atomically: true, encoding: .utf8)
+
+        let file10 = """
+        Host web
+            HostName first.example.com
+            User first
+        """
+        try file10.write(to: confD.appendingPathComponent("10-first.conf"), atomically: true, encoding: .utf8)
+
+        let rootConfigFile = tempHome.appendingPathComponent(".ssh/config")
+        try "Include ~/.ssh/conf.d/*.conf".write(to: rootConfigFile, atomically: true, encoding: .utf8)
+
+        let result = SSHConfigParser.parseFileDetailed(at: rootConfigFile.path, homeDirectory: tempHome.path)
+        XCTAssertEqual(result.hosts.count, 1)
+        // 10-first.conf 字典序在前,first obtained value 为准
+        XCTAssertEqual(result.hosts[0].hostname, "first.example.com")
+        XCTAssertEqual(result.hosts[0].user, "first")
+        XCTAssertTrue(result.issues.contains { $0.kind == .duplicateAlias("web") })
+    }
+
+    /// Test D: 纯文本 parser 依然不访问文件系统,不展开 Include
+    func testPureStringParserDoesNotExpandInclude() {
+        let config = """
+        Include ~/.ssh/conf.d/*.conf
+
+        Host foo
+            HostName foo.example.com
+        """
+        let result = SSHConfigParser.parseDetailed(config)
+        XCTAssertEqual(result.hosts.map(\.alias), ["foo"])
+        XCTAssertTrue(result.issues.contains { $0.kind == .includeNotExpanded("~/.ssh/conf.d/*.conf") })
+    }
+
+    /// Test E: Host 块内的 Include 不支持展开
+    func testIncludeInsideHostBlockNotExpanded() throws {
+        let tempDir = try createTempDirectory()
+        let extraConf = tempDir.appendingPathComponent("foo-extra.conf")
+        try "Host extra\n    HostName extra.example.com".write(to: extraConf, atomically: true, encoding: .utf8)
+
+        let rootConf = tempDir.appendingPathComponent("config")
+        let rootContent = """
+        Host foo
+            HostName foo.example.com
+            Include \(extraConf.path)
+        """
+        try rootContent.write(to: rootConf, atomically: true, encoding: .utf8)
+
+        let result = SSHConfigParser.parseFileDetailed(at: rootConf.path, homeDirectory: tempDir.path)
+        XCTAssertEqual(result.hosts.map(\.alias), ["foo"])
+        XCTAssertTrue(result.issues.contains { $0.kind == .includeNotExpanded(extraConf.path) })
+    }
+
+    /// Test F: 递归 Include 不支持展开
+    func testRecursiveIncludeNotExpanded() throws {
+        let tempDir = try createTempDirectory()
+        let secondConf = tempDir.appendingPathComponent("second.conf")
+        try "Host second\n    HostName second.example.com".write(to: secondConf, atomically: true, encoding: .utf8)
+
+        let firstConf = tempDir.appendingPathComponent("first.conf")
+        let firstContent = """
+        Host first
+            HostName first.example.com
+
+        Include \(secondConf.path)
+        """
+        try firstContent.write(to: firstConf, atomically: true, encoding: .utf8)
+
+        let rootConf = tempDir.appendingPathComponent("config")
+        try "Include \(firstConf.path)".write(to: rootConf, atomically: true, encoding: .utf8)
+
+        let result = SSHConfigParser.parseFileDetailed(at: rootConf.path, homeDirectory: tempDir.path)
+        XCTAssertEqual(result.hosts.map(\.alias), ["first"])
+        XCTAssertTrue(result.issues.contains { $0.kind == .includeNotExpanded(secondConf.path) })
+    }
+
+    /// Test G: 不存在 / 无匹配 Include 不 crash
+    func testIncludeNonExistentPathDoesNotCrash() throws {
+        let tempHome = try createTempDirectory()
+        let rootConf = tempHome.appendingPathComponent("config")
+        let rootContent = """
+        Include ~/.ssh/not-found/*.conf
+
+        Host local
+            HostName local.example.com
+        """
+        try rootContent.write(to: rootConf, atomically: true, encoding: .utf8)
+
+        let result = SSHConfigParser.parseFileDetailed(at: rootConf.path, homeDirectory: tempHome.path)
+        XCTAssertEqual(result.hosts.map(\.alias), ["local"])
+        XCTAssertTrue(result.issues.contains { $0.kind == .includeNotExpanded("~/.ssh/not-found/*.conf") })
+    }
+
+    /// Test H: 仅匹配 .conf 文件并跳过子目录与非 .conf 文件
+    func testIncludeGlobSkipsNonConfAndDirectories() throws {
+        let tempHome = try createTempDirectory()
+        let confD = tempHome.appendingPathComponent(".ssh/conf.d")
+        try FileManager.default.createDirectory(at: confD, withIntermediateDirectories: true)
+
+        try "Host valid\n    HostName valid.example.com".write(to: confD.appendingPathComponent("10-valid.conf"), atomically: true, encoding: .utf8)
+        try "# Ignore me".write(to: confD.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: confD.appendingPathComponent("subdir.conf"), withIntermediateDirectories: true)
+
+        let rootConf = tempHome.appendingPathComponent(".ssh/config")
+        try "Include ~/.ssh/conf.d/*.conf".write(to: rootConf, atomically: true, encoding: .utf8)
+
+        let result = SSHConfigParser.parseFileDetailed(at: rootConf.path, homeDirectory: tempHome.path)
+        XCTAssertEqual(result.hosts.map(\.alias), ["valid"])
+        XCTAssertFalse(result.issues.contains { issue in
+            if case .includeNotExpanded = issue.kind { return true }
+            return false
+        })
+    }
 }
 
 final class KeychainStoreTests: XCTestCase {

--- a/BerthTests/SSHConfigParserTests.swift
+++ b/BerthTests/SSHConfigParserTests.swift
@@ -433,6 +433,88 @@ final class SSHConfigParserTests: XCTestCase {
             return false
         })
     }
+
+    /// Test I: Included Host 接收 Host * fallback 选项
+    func testIncludedHostsReceiveWildcardFallbackOptions() throws {
+        let tempHome = try createTempDirectory()
+        let confD = tempHome.appendingPathComponent(".ssh/conf.d")
+        try FileManager.default.createDirectory(at: confD, withIntermediateDirectories: true)
+
+        let hostsConf = """
+        Host nas
+            HostName nas.example.com
+        """
+        try hostsConf.write(to: confD.appendingPathComponent("10-hosts.conf"), atomically: true, encoding: .utf8)
+
+        let rootConfig = """
+        Include ~/.ssh/conf.d/*.conf
+
+        Host *
+            User fallback-user
+            Port 2222
+            IdentityFile ~/.ssh/id_ed25519
+        """
+        let configFile = tempHome.appendingPathComponent(".ssh/config")
+        try rootConfig.write(to: configFile, atomically: true, encoding: .utf8)
+
+        let result = SSHConfigParser.parseFileDetailed(at: configFile.path, homeDirectory: tempHome.path)
+        XCTAssertEqual(result.hosts.count, 1)
+        XCTAssertEqual(result.hosts[0].alias, "nas")
+        XCTAssertEqual(result.hosts[0].hostname, "nas.example.com")
+        XCTAssertEqual(result.hosts[0].user, "fallback-user")
+        XCTAssertEqual(result.hosts[0].port, 2222)
+        XCTAssertEqual(result.hosts[0].identityFile, "\(tempHome.path)/.ssh/id_ed25519")
+        XCTAssertFalse(result.issues.contains { issue in
+            if case .includeNotExpanded = issue.kind { return true }
+            return false
+        })
+    }
+
+    /// Test J: Specific values 优先于 fallback,缺省项继承 Host * fallback
+    func testIncludedHostSpecificOptionsOverrideWildcardFallback() throws {
+        let tempHome = try createTempDirectory()
+        let confD = tempHome.appendingPathComponent(".ssh/conf.d")
+        try FileManager.default.createDirectory(at: confD, withIntermediateDirectories: true)
+
+        let hostsConf = """
+        Host nas
+            HostName nas.example.com
+
+        Host server
+            HostName server.example.com
+            User root
+            Port 2200
+        """
+        try hostsConf.write(to: confD.appendingPathComponent("10-hosts.conf"), atomically: true, encoding: .utf8)
+
+        let rootConfig = """
+        Include ~/.ssh/conf.d/*.conf
+
+        Host *
+            User fallback-user
+            Port 2222
+            IdentityFile ~/.ssh/id_ed25519
+        """
+        let configFile = tempHome.appendingPathComponent(".ssh/config")
+        try rootConfig.write(to: configFile, atomically: true, encoding: .utf8)
+
+        let result = SSHConfigParser.parseFileDetailed(at: configFile.path, homeDirectory: tempHome.path)
+        XCTAssertEqual(result.hosts.count, 2)
+
+        XCTAssertEqual(result.hosts[0].alias, "nas")
+        XCTAssertEqual(result.hosts[0].hostname, "nas.example.com")
+        XCTAssertEqual(result.hosts[0].user, "fallback-user")
+        XCTAssertEqual(result.hosts[0].port, 2222)
+        XCTAssertEqual(result.hosts[0].identityFile, "\(tempHome.path)/.ssh/id_ed25519")
+
+        XCTAssertEqual(result.hosts[1].alias, "server")
+        XCTAssertEqual(result.hosts[1].hostname, "server.example.com")
+        XCTAssertEqual(result.hosts[1].user, "root")
+        XCTAssertEqual(result.hosts[1].port, 2200)
+        XCTAssertEqual(result.hosts[1].identityFile, "\(tempHome.path)/.ssh/id_ed25519")
+
+        XCTAssertTrue(result.issues.isEmpty)
+    }
 }
 
 final class KeychainStoreTests: XCTestCase {


### PR DESCRIPTION
# Summary

为从 `~/.ssh/config` 导入主机的流程增加常见 OpenSSH `Include` 指令支持。

此前 Berth 能识别 `Include` 指令，但不会展开，因此定义在被包含配置文件中的主机不会出现在导入列表里。

本 PR 增加了面向真实配置文件的 Include 展开能力，同时保持现有纯字符串 parser 的确定性，并确保它不会主动访问文件系统。

# Scope

目前支持以下常见写法：

```ssh
Include ~/.ssh/conf.d/*.conf
```

以及绝对路径单文件 Include，例如：

```ssh
Include /Users/<username>/.ssh/work.conf
```

当前实现会：

- 使用配置的 home directory 展开 `~`；
- 支持常见的 `*.conf` 文件名 glob；
- 多个匹配文件按字典序依次处理；
- 在原始 `Include` 所在位置插入被包含的配置；
- 保持 Berth 现有的 first-obtained-value 语义；
- 保持 included host 的 `Host *` fallback 行为；
- 保持 `parse(_:)` / `parseDetailed(_:)` 不访问文件系统；
- 对不支持或无法展开的 Include，继续通过 `SSHConfigIssue` 报告。

# Testing

新增了以下回归测试：

- `~/.ssh/conf.d/*.conf` 展开；
- 绝对路径单文件 Include；
- 多个 included 文件的字典序处理；
- included 文件之间的 first-obtained-value 行为；
- `Host *` fallback 正确应用到 included host；
- Host 自己定义的属性正确覆盖 wildcard fallback；
- Include 路径不存在或无匹配文件；
- 非递归 Include 行为；
- 不支持上下文中的 Include 仍会被正确报告；
- 纯字符串 parser 仍然只报告 Include 未展开，不访问文件系统。

另外也在 macOS 上使用真实 `~/.ssh/config` 做了手动验证：

```ssh
Include ~/.ssh/conf.d/*.conf
```

Berth 能够：

- 正确识别 included 文件中的主机；
- 在侧栏中正常显示这些主机；
- 正确应用 fallback 配置；
- 实际完成 SSH 连接。

同时：

```text
git diff --check
```

检查通过，没有 whitespace error。

## Known limitations

本次有意只实现最常见的 Include 场景，并不尝试完整复现 OpenSSH `ssh_config` 的全部 Include 语义。

当前暂不支持：

- 递归 Include；
- `Host` block 内的 Include；
- `Match` block 内的 Include；
- 相对路径 Include；
- 一个 Include 指令中的多个路径参数；
- `**`、brace expansion、多层目录 wildcard 等复杂 glob；
- OpenSSH `%` token 展开。

当前 Include 展开采用预处理方式，将 included 内容插入待解析配置流。

因此，在 Include 之后产生的诊断信息，行号可能对应预处理后的配置流，而不是原始根配置文件中的实际行号。所以报错可能会产生行号反馈错误的问题。

这个诊断行号限制不会影响主机解析结果或 SSH 连接行为。为了保持本 PR 范围集中，暂不在本次修改中处理，后续可以单独改进。