### PR TITLE
修复：在单元测试环境禁用 CloudKit 初始化

### DIFF
--- a/Berth/Core/Storage/Persistence.swift
+++ b/Berth/Core/Storage/Persistence.swift
@@ -6,13 +6,16 @@ enum Persistence {
     static func makeContainer() -> ModelContainer {
         let schema = Schema([Host.self, HostGroup.self, SSHKeyRecord.self, PortForward.self, Snippet.self, Workspace.self, Trigger.self])
         let transient = ProcessInfo.processInfo.environment["BERTH_TRANSIENT_STORE"] == "1"
+        let isTesting = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+            || ProcessInfo.processInfo.environment["XCTestBundlePath"] != nil
+            || NSClassFromString("XCTestCase") != nil
         let configuration: ModelConfiguration
         // CloudKit 私有库同步:主机/分组/转发/片段/模板/触发器 + 密钥元数据(公钥不是机密,
         // 记录同步后 keyID 跨设备仍可解析;私钥本体只在各设备 Keychain,永不上传)。
         // 镜像主机(ssh_config)是内存态,天然不参与同步。
-        // 临时库(自动化/演示)与 BERTH_DISABLE_SYNC=1(调试逃生门)不接 CloudKit。
-        let syncDisabled = ProcessInfo.processInfo.environment["BERTH_DISABLE_SYNC"] == "1"
-        if transient {
+        // 临时库(自动化/演示)、测试环境与 BERTH_DISABLE_SYNC=1(调试逃生门)不接 CloudKit。
+        let syncDisabled = ProcessInfo.processInfo.environment["BERTH_DISABLE_SYNC"] == "1" || isTesting
+        if transient || isTesting {
             configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true, cloudKitDatabase: .none)
         } else if syncDisabled {
             configuration = ModelConfiguration(schema: schema, url: storeURL(), cloudKitDatabase: .none)


### PR DESCRIPTION
## 变更概述

- 在 XCTest 环境中自动使用内存 SwiftData 存储。
- 测试启动时禁用 CloudKit 数据库配置，避免缺少 iCloud entitlement 时在测试用例执行前崩溃。
- 普通 App 启动、正式构建及显式 `BERTH_DISABLE_SYNC` 行为保持不变。

## 背景

未使用作者 Developer Team / CloudKit provisioning profile 的本地测试构建，会在初始化 SwiftData 的 CloudKit 容器时失败，导致真正的单元测试尚未开始就退出。后续 PTY 与 SFTP 改动都会新增测试，因此先单独提交这个最小测试启动修复，便于后续 PR 独立验证和审查。

## 影响范围

- 仅修改 `Berth/Core/Storage/Persistence.swift`。
- 仅在检测到 XCTest 运行环境时改变存储配置。
- 不包含 PTY、SFTP pipeline、拖拽生命周期或下载目标事务代码。

## 验证

- 已确认无正式 CloudKit entitlement 的 macOS XCTest runner 可以进入并执行测试。
- 本 PR 未验证 iOS；改动目标是当前 macOS 测试启动路径。

## 后续 PR 顺序

1. 本 PR：测试环境 CloudKit 启动修复
2. PTY / SSH 会话退出分类与连接保留
3. SFTP pipeline 目录下载
4. Finder 拖拽下载生命周期与临时文件回收
5. 下载目标原子提交与同名冲突保护

后续 PR 将按依赖顺序提交，避免向上游重复夹带前置提交。
