### PR TITLE
修复：区分 PTY 正常退出与连接异常中断

### DIFF
--- a/Berth/Core/SSH/SessionTerminationClassifier.swift
+++ b/Berth/Core/SSH/SessionTerminationClassifier.swift
@@ -1,0 +1,133 @@
+import Foundation
+import NIOCore
+import NIOSSH
+
+/// 会话终止的归类结果:
+/// - `userInitiated`: 用户主动点击断开/关闭标签页,或任务被取消
+/// - `cleanShellExit`: 远端 shell 正常 exit/logout (withPTY 干净返回无错误)
+/// - `transportFailure`: 通道被关闭、TCP 断开、网络超时/不可达、认证失败等异常
+enum SessionTerminationDisposition: Equatable, Sendable {
+    case userInitiated
+    case cleanShellExit
+    case transportFailure(message: String)
+}
+
+/// 传输层异常的大类,用于结构化诊断日志
+enum TransportErrorCategory: String, Sendable, Equatable {
+    case channelClosed = "channelClosed"
+    case tcpShutdown = "tcpShutdown"
+    case networkUnreachable = "networkUnreachable"
+    case connectionReset = "connectionReset"
+    case connectionRefused = "connectionRefused"
+    case timedOut = "timedOut"
+    case authentication = "authentication"
+    case localShellExited = "localShellExited"
+    case unknown = "unknown"
+}
+
+/// 集中判定 SSH/本地终端会话终止的原因与处理策略。
+/// 核心原则:
+/// 1. 只有无错误干净返回(withPTY / 本地进程正常返回)且非用户取消,才判定为 cleanShellExit。
+/// 2. 已连接会话遇到任何异常(包括 ChannelError.alreadyClosed、tcpShutdown、未知错误),
+///    保守归类为 transportFailure,保留终端 pane 与 scrollback 并允许自动重连,
+///    绝不能因为未命中网络关键词而误判为正常退出。
+struct SessionTerminationClassifier: Sendable {
+
+    static func classify(
+        error: Error?,
+        everConnected: Bool,
+        userInitiated: Bool,
+        isLocal: Bool = false,
+        hostname: String = "",
+        port: Int = 22,
+        authMethod: AuthMethodKind? = nil
+    ) -> SessionTerminationDisposition {
+        if userInitiated || error is CancellationError {
+            return .userInitiated
+        }
+
+        guard let error else {
+            return userInitiated ? .userInitiated : .cleanShellExit
+        }
+
+        let message: String
+        if isLocal {
+            message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        } else {
+            message = SSHErrorMapper.friendlyMessage(
+                for: error,
+                hostname: hostname,
+                port: port,
+                authMethod: authMethod
+            )
+        }
+
+        return .transportFailure(message: message)
+    }
+
+    static func categorize(error: Error) -> TransportErrorCategory {
+        if let channelError = error as? ChannelError {
+            switch channelError {
+            case .alreadyClosed, .ioOnClosedChannel, .inputClosed, .outputClosed, .eof:
+                return .channelClosed
+            default:
+                return .channelClosed
+            }
+        }
+
+        if let niosshError = error as? NIOSSHError {
+            if niosshError.type == .tcpShutdown {
+                return .tcpShutdown
+            }
+            return .unknown
+        }
+
+        if let posix = error as? POSIXError {
+            switch posix.code {
+            case .ECONNRESET, .EPIPE, .ENETRESET:
+                return .connectionReset
+            case .EHOSTUNREACH, .ENETUNREACH, .EHOSTDOWN, .ENETDOWN:
+                return .networkUnreachable
+            case .ETIMEDOUT:
+                return .timedOut
+            case .ECONNREFUSED:
+                return .connectionRefused
+            default:
+                return .unknown
+            }
+        }
+
+        if error is TerminalSession.SessionError {
+            return .localShellExited
+        }
+
+        if error is KeyboardInteractiveAuthError || error is SSHDialer.DialError || error is HostKeyError {
+            return .authentication
+        }
+
+        let raw = String(describing: error).lowercased()
+        if raw.contains("already closed") || raw.contains("channel closed") || raw.contains("closed channel") {
+            return .channelClosed
+        }
+        if raw.contains("tcpshutdown") || raw.contains("tcp shutdown") {
+            return .tcpShutdown
+        }
+        if raw.contains("reset") || raw.contains("broken pipe") {
+            return .connectionReset
+        }
+        if raw.contains("unreachable") || raw.contains("no route") || raw.contains("host is down") || raw.contains("network is down") {
+            return .networkUnreachable
+        }
+        if raw.contains("timed out") || raw.contains("timeout") {
+            return .timedOut
+        }
+        if raw.contains("refused") {
+            return .connectionRefused
+        }
+        if raw.contains("auth") || raw.contains("permission denied") {
+            return .authentication
+        }
+
+        return .unknown
+    }
+}

--- a/Berth/Core/SSH/TerminalSession.swift
+++ b/Berth/Core/SSH/TerminalSession.swift
@@ -181,6 +181,7 @@ final class TerminalSession: Identifiable {
         sessionTask = Task {
             var disconnectReason: DisconnectReason
             var shellExited = false
+            let caughtError: Error?
             do {
                 if spec.isLocal {
                     try await runLocalSession()
@@ -200,27 +201,38 @@ final class TerminalSession: Identifiable {
                         try await runSession()
                     }
                 }
-                // 干净返回(收到 exit-status 0 / 干净 EOF)= shell 正常退出
-                shellExited = !userInitiatedDisconnect
-                disconnectReason = userInitiatedDisconnect ? .userInitiated : .remoteClosed
-            } catch is CancellationError {
-                disconnectReason = .userInitiated
+                caughtError = nil
             } catch {
-                if userInitiatedDisconnect {
-                    disconnectReason = .userInitiated
-                } else if everConnected, !Self.isConnectionStageError(error), Self.isCleanShellExit(error) {
-                    // 抛出的其实是通道 EOF/关闭(exit 与连接关闭竞速),视为 shell 退出。
-                    // 连接阶段的失败(认证被拒/私钥解析/交互认证取消)不可能是 shell 退出 ——
-                    // 它们的报错不含网络关键词,若不先排除会被误判成干净退出,
-                    // 自动重连一失败 pane 就无声关掉,诊断信息全丢
-                    shellExited = true
-                    disconnectReason = .remoteClosed
-                } else if spec.isLocal {
-                    // 本地会话只会抛自家的 SessionError(启动失败),不走 SSH 错误映射
-                    disconnectReason = .error((error as? LocalizedError)?.errorDescription ?? error.localizedDescription)
-                } else {
-                    disconnectReason = .error(SSHErrorMapper.friendlyMessage(for: error, hostname: spec.hostname, port: spec.port, authMethod: spec.authMethod))
-                }
+                caughtError = error
+            }
+
+            let disposition = SessionTerminationClassifier.classify(
+                error: caughtError,
+                everConnected: everConnected,
+                userInitiated: userInitiatedDisconnect,
+                isLocal: spec.isLocal,
+                hostname: spec.hostname,
+                port: spec.port,
+                authMethod: spec.authMethod
+            )
+
+            if let error = caughtError {
+                let category = SessionTerminationClassifier.categorize(error: error)
+                DebugLog.append("session terminated host=\(spec.hostname):\(spec.port) disposition=\(disposition) category=\(category.rawValue) everConnected=\(everConnected)")
+            } else {
+                DebugLog.append("session terminated host=\(spec.hostname):\(spec.port) disposition=\(disposition) everConnected=\(everConnected)")
+            }
+
+            switch disposition {
+            case .userInitiated:
+                shellExited = false
+                disconnectReason = .userInitiated
+            case .cleanShellExit:
+                shellExited = true
+                disconnectReason = .remoteClosed
+            case .transportFailure(let message):
+                shellExited = false
+                disconnectReason = .error(message)
             }
             state = .disconnected(disconnectReason)
             // 会话结束时质询弹窗必须收掉:服务器可能在用户找手机输 MFA 码时超时断开
@@ -249,29 +261,6 @@ final class TerminalSession: Identifiable {
                 maybeScheduleReconnect(after: disconnectReason)
             }
         }
-    }
-
-    /// 连接/认证阶段自家抛的错误类型 —— 这些永远不该被归类成「shell 正常退出」
-    private static func isConnectionStageError(_ error: Error) -> Bool {
-        error is SessionError
-            || error is SSHDialer.DialError
-            || error is PrivateKeyFormat.ConversionError
-            || error is KeyboardInteractiveAuthError
-            || error is HostKeyError
-            || error is AgentAuthError
-    }
-
-    /// 判断断开是否为 shell 正常退出(通道 EOF/关闭)而非网络异常(reset/timeout/refused…)
-    private static func isCleanShellExit(_ error: Error) -> Bool {
-        let s = String(describing: error).lowercased()
-        // 明确的网络异常关键词 → 不是干净退出,应保留横幅并重连
-        let networky = ["reset", "refused", "timed out", "timeout", "unreachable",
-                        "no route", "broken pipe", "not connected", "connection closed by",
-                        "handshake", "posix"]
-        if networky.contains(where: { s.contains($0) }) { return false }
-        // 其余(通道 EOF/关闭/退出码/未知)一律按 shell 退出处理 —— 已连上时通道关闭
-        // 绝大多数就是用户敲了 exit;真正的网络掉线基本都会命中上面的关键词
-        return true
     }
 
     func disconnect() {

--- a/BerthTests/SessionTerminationClassifierTests.swift
+++ b/BerthTests/SessionTerminationClassifierTests.swift
@@ -1,0 +1,361 @@
+import XCTest
+import NIOCore
+import NIOSSH
+import Citadel
+@testable import Berth
+
+final class SessionTerminationClassifierTests: XCTestCase {
+
+    private struct ArbitraryError: Error, CustomStringConvertible {
+        var description: String { "Some unknown internal failure" }
+    }
+
+    func testUserInitiatedReturnsUserInitiated() {
+        let res1 = SessionTerminationClassifier.classify(
+            error: nil,
+            everConnected: true,
+            userInitiated: true
+        )
+        XCTAssertEqual(res1, .userInitiated)
+
+        let res2 = SessionTerminationClassifier.classify(
+            error: ChannelError.alreadyClosed,
+            everConnected: true,
+            userInitiated: true
+        )
+        XCTAssertEqual(res2, .userInitiated)
+    }
+
+    func testCancellationErrorReturnsUserInitiated() {
+        let res = SessionTerminationClassifier.classify(
+            error: CancellationError(),
+            everConnected: true,
+            userInitiated: false
+        )
+        XCTAssertEqual(res, .userInitiated)
+    }
+
+    func testCleanExitReturnsCleanShellExit() {
+        let res = SessionTerminationClassifier.classify(
+            error: nil,
+            everConnected: true,
+            userInitiated: false
+        )
+        XCTAssertEqual(res, .cleanShellExit)
+    }
+
+    func testChannelErrorAlreadyClosedIsTransportFailure() {
+        let res = SessionTerminationClassifier.classify(
+            error: ChannelError.alreadyClosed,
+            everConnected: true,
+            userInitiated: false,
+            hostname: "test.example.com",
+            port: 22
+        )
+        guard case .transportFailure(let msg) = res else {
+            XCTFail("Expected transportFailure, got \(res)")
+            return
+        }
+        XCTAssertFalse(msg.isEmpty)
+        XCTAssertEqual(SessionTerminationClassifier.categorize(error: ChannelError.alreadyClosed), .channelClosed)
+    }
+
+    func testChannelErrorIoOnClosedChannelIsTransportFailure() {
+        let res = SessionTerminationClassifier.classify(
+            error: ChannelError.ioOnClosedChannel,
+            everConnected: true,
+            userInitiated: false
+        )
+        guard case .transportFailure = res else {
+            XCTFail("Expected transportFailure, got \(res)")
+            return
+        }
+        XCTAssertEqual(SessionTerminationClassifier.categorize(error: ChannelError.ioOnClosedChannel), .channelClosed)
+    }
+
+    func testChannelErrorInputClosedIsTransportFailure() {
+        let res = SessionTerminationClassifier.classify(
+            error: ChannelError.inputClosed,
+            everConnected: true,
+            userInitiated: false
+        )
+        guard case .transportFailure = res else {
+            XCTFail("Expected transportFailure, got \(res)")
+            return
+        }
+        XCTAssertEqual(SessionTerminationClassifier.categorize(error: ChannelError.inputClosed), .channelClosed)
+    }
+
+    func testNIOSSHErrorTcpShutdownIsTransportFailure() {
+        struct MockTCPShutdownError: Error, CustomStringConvertible {
+            var description: String { "NIOSSHError.tcpShutdown: TCP connection closed" }
+        }
+        let tcpShutdown = MockTCPShutdownError()
+        let res = SessionTerminationClassifier.classify(
+            error: tcpShutdown,
+            everConnected: true,
+            userInitiated: false,
+            hostname: "test.example.com",
+            port: 22
+        )
+        guard case .transportFailure = res else {
+            XCTFail("Expected transportFailure, got \(res)")
+            return
+        }
+        XCTAssertEqual(SessionTerminationClassifier.categorize(error: tcpShutdown), .tcpShutdown)
+    }
+
+    func testPOSIXErrorsAreTransportFailure() {
+        let codes: [(POSIXErrorCode, TransportErrorCategory)] = [
+            (.ECONNRESET, .connectionReset),
+            (.EHOSTUNREACH, .networkUnreachable),
+            (.ENETUNREACH, .networkUnreachable),
+            (.ETIMEDOUT, .timedOut),
+            (.ECONNREFUSED, .connectionRefused),
+        ]
+        for (code, expectedCategory) in codes {
+            let err = POSIXError(code)
+            let res = SessionTerminationClassifier.classify(
+                error: err,
+                everConnected: true,
+                userInitiated: false
+            )
+            guard case .transportFailure = res else {
+                XCTFail("Expected transportFailure for \(code), got \(res)")
+                continue
+            }
+            XCTAssertEqual(SessionTerminationClassifier.categorize(error: err), expectedCategory)
+        }
+    }
+
+    func testUnknownErrorAfterConnectedIsTransportFailure() {
+        // 关键原则：已连接会话遇到未知异常，绝不能因未匹配网络关键词而误判为正常 shell exit！
+        let err = ArbitraryError()
+        let res = SessionTerminationClassifier.classify(
+            error: err,
+            everConnected: true,
+            userInitiated: false,
+            hostname: "10.0.0.1",
+            port: 22
+        )
+        guard case .transportFailure(let msg) = res else {
+            XCTFail("Unknown error must be classified as transportFailure, but got \(res)")
+            return
+        }
+        XCTAssertTrue(msg.contains("Some unknown internal failure") || msg.contains("连接失败"))
+        XCTAssertEqual(SessionTerminationClassifier.categorize(error: err), .unknown)
+    }
+
+    func testLocalShellExitIsTransportFailure() {
+        let err = TerminalSession.SessionError.localShellExited(1, "/bin/zsh")
+        let res = SessionTerminationClassifier.classify(
+            error: err,
+            everConnected: true,
+            userInitiated: false,
+            isLocal: true
+        )
+        guard case .transportFailure = res else {
+            XCTFail("Expected transportFailure, got \(res)")
+            return
+        }
+        XCTAssertEqual(SessionTerminationClassifier.categorize(error: err), .localShellExited)
+    }
+
+    // MARK: - PTY Lifecycle & Termination State Machine Tests (M-02)
+
+    func testPTYPerformSuccessAndCleanupSuccessYieldsCleanExit() async {
+        do {
+            try await SSHClient.executeTTYLifecycle(
+                perform: { /* clean exit */ },
+                cleanupClose: { /* channel.close() succeeds */ }
+            )
+            let disposition = SessionTerminationClassifier.classify(
+                error: nil,
+                everConnected: true,
+                userInitiated: false
+            )
+            XCTAssertEqual(disposition, .cleanShellExit)
+        } catch {
+            XCTFail("Expected clean exit, but caught \(error)")
+        }
+    }
+
+    func testPTYPerformSuccessAndCleanupAlreadyClosedYieldsCleanExit() async {
+        do {
+            try await SSHClient.executeTTYLifecycle(
+                perform: { /* clean exit */ },
+                cleanupClose: { throw ChannelError.alreadyClosed }
+            )
+            // ChannelError.alreadyClosed absorbed during cleanup; error is nil
+            let disposition = SessionTerminationClassifier.classify(
+                error: nil,
+                everConnected: true,
+                userInitiated: false
+            )
+            XCTAssertEqual(disposition, .cleanShellExit)
+        } catch {
+            XCTFail("Expected clean exit, but cleanup alreadyClosed threw: \(error)")
+        }
+    }
+
+    func testPTYPerformThrowsAlreadyClosedPreservesErrorAndYieldsTransportFailure() async {
+        var caught: Error?
+        do {
+            try await SSHClient.executeTTYLifecycle(
+                perform: { throw ChannelError.alreadyClosed },
+                cleanupClose: { throw ChannelError.alreadyClosed }
+            )
+            XCTFail("Should have thrown error")
+        } catch {
+            caught = error
+        }
+
+        guard let channelError = caught as? ChannelError, channelError == .alreadyClosed else {
+            XCTFail("Expected ChannelError.alreadyClosed, got \(String(describing: caught))")
+            return
+        }
+        let disposition = SessionTerminationClassifier.classify(
+            error: channelError,
+            everConnected: true,
+            userInitiated: false
+        )
+        guard case .transportFailure = disposition else {
+            XCTFail("Expected transportFailure, got \(disposition)")
+            return
+        }
+    }
+
+    func testPTYPerformThrowsTcpShutdownAndCleanupAlreadyClosedPreservesTcpShutdown() async {
+        struct MockTCPShutdownError: Error, CustomStringConvertible, Equatable {
+            var description: String { "NIOSSHError.tcpShutdown" }
+        }
+
+        var caught: Error?
+        do {
+            try await SSHClient.executeTTYLifecycle(
+                perform: { throw MockTCPShutdownError() },
+                cleanupClose: { throw ChannelError.alreadyClosed }
+            )
+            XCTFail("Should have thrown error")
+        } catch {
+            caught = error
+        }
+
+        XCTAssertTrue(caught is MockTCPShutdownError, "Must preserve original tcpShutdown error and NOT replace with alreadyClosed")
+        let disposition = SessionTerminationClassifier.classify(
+            error: caught,
+            everConnected: true,
+            userInitiated: false
+        )
+        guard case .transportFailure = disposition else {
+            XCTFail("Expected transportFailure, got \(disposition)")
+            return
+        }
+    }
+
+    func testPTYPerformThrowsCustomErrorAAndCleanupThrowsErrorBPreservesErrorA() async {
+        struct CustomErrorA: Error, Equatable {}
+        struct CustomErrorB: Error, Equatable {}
+
+        var caught: Error?
+        do {
+            try await SSHClient.executeTTYLifecycle(
+                perform: { throw CustomErrorA() },
+                cleanupClose: { throw CustomErrorB() }
+            )
+            XCTFail("Should have thrown error")
+        } catch {
+            caught = error
+        }
+
+        XCTAssertTrue(caught is CustomErrorA, "Must preserve business error A and ignore cleanup error B")
+        let disposition = SessionTerminationClassifier.classify(
+            error: caught,
+            everConnected: true,
+            userInitiated: false
+        )
+        guard case .transportFailure = disposition else {
+            XCTFail("Expected transportFailure, got \(disposition)")
+            return
+        }
+    }
+
+    // MARK: - CommandStreamTerminationState Regression Tests (M-02)
+
+    func testInteractiveTerminationStateWithExitStatusYieldsCleanFinish() {
+        let stateZero = SSHClient.CommandStreamTerminationState(isInteractive: true, exitCode: 0)
+        let resZero = stateZero.resolveTermination(error: nil)
+        XCTAssertNoThrow(try resZero.get())
+
+        let stateNonZero = SSHClient.CommandStreamTerminationState(isInteractive: true, exitCode: 1)
+        let resNonZero = stateNonZero.resolveTermination(error: nil)
+        XCTAssertNoThrow(try resNonZero.get())
+    }
+
+    func testInteractiveTerminationStateWithExitSignalYieldsCleanFinish() {
+        let stateSignal = SSHClient.CommandStreamTerminationState(isInteractive: true, exitSignal: "TERM")
+        let resSignal = stateSignal.resolveTermination(error: nil)
+        XCTAssertNoThrow(try resSignal.get())
+    }
+
+    func testInteractiveTerminationStateWithoutExitEvidenceYieldsTransportError() {
+        // Transport teardown / omitted exit evidence:
+        // RFC 4254 §6.10 specifies sending exit-status is RECOMMENDED (SHOULD, not MUST).
+        // Berth deliberately adopts a conservative fail-closed policy requiring explicit exit evidence
+        // (exit-status or exit-signal) for interactive PTY/TTY sessions to distinguish clean exit from transport teardown.
+        let stateTeardown = SSHClient.CommandStreamTerminationState(isInteractive: true, exitCode: nil, exitSignal: nil)
+        let resTeardown = stateTeardown.resolveTermination(error: nil)
+        switch resTeardown {
+        case .success:
+            XCTFail("Must not succeed without exit evidence")
+        case .failure(let err):
+            guard let channelError = err as? ChannelError, channelError == .eof else {
+                XCTFail("Expected ChannelError.eof, got \(err)")
+                return
+            }
+            let disposition = SessionTerminationClassifier.classify(
+                error: channelError,
+                everConnected: true,
+                userInitiated: false
+            )
+            guard case .transportFailure = disposition else {
+                XCTFail("Expected transportFailure, got \(disposition)")
+                return
+            }
+        }
+    }
+
+    func testInteractiveTerminationStateWithOriginalErrorPreservesError() {
+        struct MockNetworkError: Error, Equatable {}
+        let state = SSHClient.CommandStreamTerminationState(isInteractive: true, exitCode: 0)
+        let res = state.resolveTermination(error: MockNetworkError())
+        switch res {
+        case .success:
+            XCTFail("Must fail when original error is present")
+        case .failure(let err):
+            XCTAssertTrue(err is MockNetworkError)
+        }
+    }
+
+    func testNonInteractiveTerminationStateResolutions() {
+        let successCommand = SSHClient.CommandStreamTerminationState(isInteractive: false, exitCode: 0)
+        XCTAssertNoThrow(try successCommand.resolveTermination(error: nil).get())
+
+        let failedCommand = SSHClient.CommandStreamTerminationState(isInteractive: false, exitCode: 2)
+        switch failedCommand.resolveTermination(error: nil) {
+        case .success:
+            XCTFail("Must fail with non-zero exit code")
+        case .failure(let err):
+            XCTAssertTrue(err is SSHClient.CommandFailed)
+            XCTAssertEqual((err as? SSHClient.CommandFailed)?.exitCode, 2)
+        }
+
+        let missingEvidenceCommand = SSHClient.CommandStreamTerminationState(isInteractive: false, exitCode: nil)
+        switch missingEvidenceCommand.resolveTermination(error: nil) {
+        case .success:
+            XCTFail("Must fail without exit code")
+        case .failure(let err):
+            XCTAssertEqual(err as? ChannelError, .eof)
+        }
+    }
+}

--- a/vendor/Citadel/Sources/Citadel/TTY/Client/TTY.swift
+++ b/vendor/Citadel/Sources/Citadel/TTY/Client/TTY.swift
@@ -38,6 +38,9 @@ public struct ExecCommandStream {
             case .exit(let status):
                 stdout.finish(throwing: SSHClient.CommandFailed(exitCode: status))
                 stderr.finish(throwing: SSHClient.CommandFailed(exitCode: status))
+            case .exitSignal:
+                stdout.finish(throwing: SSHClient.CommandFailed(exitCode: 128))
+                stderr.finish(throwing: SSHClient.CommandFailed(exitCode: 128))
             }
         }
     }
@@ -100,6 +103,7 @@ final class ExecCommandHandler: ChannelDuplexHandler, Sendable {
         case stderr(ByteBuffer)
         case eof(Error?)
         case exit(Int)
+        case exitSignal(String)
     }
     
     typealias InboundIn = SSHChannelData
@@ -133,6 +137,8 @@ final class ExecCommandHandler: ChannelDuplexHandler, Sendable {
             onOutput(context.channel, .eof(CitadelError.channelFailure))
         case let status as SSHChannelRequestEvent.ExitStatus:
             onOutput(context.channel, .exit(status.exitStatus))
+        case let signal as SSHChannelRequestEvent.ExitSignal:
+            onOutput(context.channel, .exitSignal(signal.signalName))
         default:
             self.logger.debug("Received unknown channel event in command handler: \(event)")
             context.fireUserInboundEventTriggered(event)
@@ -262,6 +268,55 @@ extension SSHClient {
         ).output
     }
 
+    /// [Berth patch] 跟踪命令或会话流的终止状态。
+    /// RFC 4254 §6.10 规定发送 exit-status 属于 RECOMMENDED (SHOULD) 而非 MUST。
+    /// 为避免底层连接断开或静默拆除被误判为 cleanShellExit 导致终端 tab 被误关，
+    /// Berth 刻意采用保守的 fail-closed 策略：交互式 PTY/TTY 会话必须收到明确退出证据（exit-status 或 exit-signal），
+    /// EOF 才能以 clean finish 正常结束；缺少证据时产生 transport error (ChannelError.eof)。
+    public struct CommandStreamTerminationState: Sendable, Equatable {
+        public let isInteractive: Bool
+        public var exitCode: Int?
+        public var exitSignal: String?
+
+        public init(isInteractive: Bool, exitCode: Int? = nil, exitSignal: String? = nil) {
+            self.isInteractive = isInteractive
+            self.exitCode = exitCode
+            self.exitSignal = exitSignal
+        }
+
+        public var hasExitEvidence: Bool {
+            exitCode != nil || exitSignal != nil
+        }
+
+        public func resolveTermination(error: Error?) -> Result<Void, Error> {
+            if let error {
+                return .failure(error)
+            }
+            if isInteractive {
+                if hasExitEvidence {
+                    return .success(())
+                } else {
+                    // 交互式 PTY/TTY 在未收到任何退出证据（exit-status 或 exit-signal）的情况下收到 EOF。
+                    // 依据 Berth 保守的 fail-closed 策略（防范静默传输拆除误关终端），
+                    // 将其判定为 transport error (ChannelError.eof)，确保上层归类为 transportFailure 并保留终端 tab。
+                    return .failure(ChannelError.eof)
+                }
+            } else {
+                if let exitCode {
+                    if exitCode != 0 {
+                        return .failure(SSHClient.CommandFailed(exitCode: exitCode))
+                    } else {
+                        return .success(())
+                    }
+                } else if exitSignal != nil {
+                    return .failure(SSHClient.CommandFailed(exitCode: 128))
+                } else {
+                    return .failure(ChannelError.eof)
+                }
+            }
+        }
+    }
+
     enum CommandMode {
         case pty(SSHChannelRequestEvent.PseudoTerminalRequest), tty(command: String?), command(String)
     }
@@ -274,6 +329,15 @@ extension SSHClient {
 
         let hasReceivedChannelSuccess = NIOLockedValueBox<Bool>(false)
         let exitCode = NIOLockedValueBox<Int?>(nil)
+        let exitSignal = NIOLockedValueBox<String?>(nil)
+
+        let isInteractive: Bool
+        switch mode {
+        case .pty, .tty(command: nil):
+            isInteractive = true
+        case .tty(command: .some), .command:
+            isInteractive = false
+        }
 
         let handler = ExecCommandHandler(logger: logger) { channel, output in
             switch output {
@@ -283,12 +347,16 @@ extension SSHClient {
                 streamContinuation.yield(.stderr(stderr))
             case .eof(let error):
                 self.logger.debug("EOF triggered, ending the command stream.")
-                if let error {
-                    streamContinuation.finish(throwing: error)
-                } else if let exitCode = exitCode.withLockedValue({ $0 }), exitCode != 0 {
-                    streamContinuation.finish(throwing: CommandFailed(exitCode: exitCode))
-                } else {
+                let state = CommandStreamTerminationState(
+                    isInteractive: isInteractive,
+                    exitCode: exitCode.withLockedValue({ $0 }),
+                    exitSignal: exitSignal.withLockedValue({ $0 })
+                )
+                switch state.resolveTermination(error: error) {
+                case .success:
                     streamContinuation.finish()
+                case .failure(let failureError):
+                    streamContinuation.finish(throwing: failureError)
                 }
             case .channelSuccess:
                 if case .tty(.some(let command)) = mode, !hasReceivedChannelSuccess.withLockedValue({ $0 }) {
@@ -302,6 +370,9 @@ extension SSHClient {
             case .exit(let status):
                 self.logger.debug("Process exited with status code \(status). Will await on EOF for correct exit")
                 exitCode.withLockedValue({ $0 = status })
+            case .exitSignal(let signal):
+                self.logger.debug("Process exited with signal \(signal). Will await on EOF for correct exit")
+                exitSignal.withLockedValue({ $0 = signal })
             }
         }
 
@@ -340,6 +411,46 @@ extension SSHClient {
         return (channel, stream)
     }
 
+    /// [Berth patch] 统一的 PTY/TTY 执行与清理生命周期。
+    /// 确保：
+    /// 1. perform 业务异常绝对优先，cleanup 失败绝不覆盖原始业务异常。
+    /// 2. 远端先行 clean close 导致的 alreadyClosed / eof 清理错误在正常退出时不抛出。
+    public static func executeTTYLifecycle(
+        perform: () async throws -> Void,
+        cleanupClose: () async throws -> Void
+    ) async throws {
+        do {
+            try await perform()
+            do {
+                try await cleanupClose()
+            } catch ChannelError.alreadyClosed, ChannelError.eof {
+                // [Berth patch] Remote already cleanly closed the channel; benign on clean exit
+            }
+        } catch {
+            // [Berth patch] Cleanup is best effort; do not let cleanup error override original error
+            try? await cleanupClose()
+            throw error
+        }
+    }
+
+    @available(macOS 15.0, *)
+    internal func runTTYSession(
+        channel: Channel,
+        output: AsyncThrowingStream<ExecCommandOutput, Error>,
+        perform: (_ inbound: TTYOutput, _ outbound: TTYStdinWriter) async throws -> Void
+    ) async throws {
+        let inbound = TTYOutput(sequence: output)
+        let outbound = TTYStdinWriter(channel: channel)
+        try await SSHClient.executeTTYLifecycle(
+            perform: {
+                try await perform(inbound, outbound)
+            },
+            cleanupClose: {
+                try await channel.close()
+            }
+        )
+    }
+
     /// Creates a pseudo-terminal (PTY) session and executes the provided closure with input/output streams
     /// - Parameters:
     ///   - request: PTY configuration parameters
@@ -356,19 +467,7 @@ extension SSHClient {
             environment: environment,
             mode: .pty(request)
         )
-
-        func close() async throws {
-            try await channel.close()
-        }
-
-        do {
-            let inbound = TTYOutput(sequence: output)
-            try await perform(inbound, TTYStdinWriter(channel: channel))
-            try await close()
-        } catch {
-            try await close()
-            throw error
-        }
+        try await runTTYSession(channel: channel, output: output, perform: perform)
     }
 
     /// Creates a TTY session and executes the provided closure with input/output streams
@@ -405,19 +504,7 @@ extension SSHClient {
             environment: environment,
             mode: .tty(command: nil)
         )
-
-        func close() async throws {
-            try await channel.close()
-        }
-
-        do {
-            let inbound = TTYOutput(sequence: output)
-            try await perform(inbound, TTYStdinWriter(channel: channel))
-            try await close()
-        } catch {
-            try await close()
-            throw error
-        }
+        try await runTTYSession(channel: channel, output: output, perform: perform)
     }
 
     /// Executes a command and returns separate stdout and stderr streams

--- a/vendor/Citadel/Sources/Citadel/TTY/Client/TTY.swift
+++ b/vendor/Citadel/Sources/Citadel/TTY/Client/TTY.swift
@@ -38,6 +38,7 @@ public struct ExecCommandStream {
             case .exit(let status):
                 stdout.finish(throwing: SSHClient.CommandFailed(exitCode: status))
                 stderr.finish(throwing: SSHClient.CommandFailed(exitCode: status))
+            // [Berth patch] Preserve RFC 4254 exit-signal as explicit termination evidence.
             case .exitSignal:
                 stdout.finish(throwing: SSHClient.CommandFailed(exitCode: 128))
                 stderr.finish(throwing: SSHClient.CommandFailed(exitCode: 128))
@@ -103,6 +104,7 @@ final class ExecCommandHandler: ChannelDuplexHandler, Sendable {
         case stderr(ByteBuffer)
         case eof(Error?)
         case exit(Int)
+        // [Berth patch] Forward exit-signal instead of discarding it as an unknown event.
         case exitSignal(String)
     }
     
@@ -137,6 +139,7 @@ final class ExecCommandHandler: ChannelDuplexHandler, Sendable {
             onOutput(context.channel, .eof(CitadelError.channelFailure))
         case let status as SSHChannelRequestEvent.ExitStatus:
             onOutput(context.channel, .exit(status.exitStatus))
+        // [Berth patch] Capture RFC 4254 exit-signal for conservative termination classification.
         case let signal as SSHChannelRequestEvent.ExitSignal:
             onOutput(context.channel, .exitSignal(signal.signalName))
         default:

--- a/vendor/PATCHES.md
+++ b/vendor/PATCHES.md
@@ -152,6 +152,31 @@ Citadel 自带 `DiffieHellmanGroup14Sha1/Sha256` 与 `AES128CTR` 实现(Berth �
   group14-sha1+ssh-rsa(SHA-1)、curve25519+仅 RSA host key(内置 ECDH 路径验签)、
   现代 sshd 回归;单测 120 项;`BERTH_M1_AUTOTEST` 对 2224 全流程 ALL_DONE。
 
+## 补丁:PTY / TTY 退出时区分正常退出与传输拆除 (Clean Exit vs Transport Teardown)
+
+**动机与基线**:
+- 基线：Citadel 0.12.0
+- 修改文件：`vendor/Citadel/Sources/Citadel/TTY/Client/TTY.swift`
+- 原始问题：
+  1. Citadel 的 `withPTY` 与 `withTTY` 在业务闭包 `perform` 执行完毕后调用 `channel.close()` 进行通道清理。当远端 shell 正常 exit 时，远端已先发送 EOF / exit-status / CHANNEL_CLOSE，此时 NIOSSH 会让后续的重复 close 抛出 `ChannelError.alreadyClosed`。原逻辑直接把该 cleanup 错误抛出，导致上层（Berth）将正常的 shell exit 误判为 `transportFailure`，进而触发自动重连。
+  2. 当 `perform` 自身发生异常时，原逻辑在 `catch` 块中调用 `try await close()`，若 `close()` 失败会直接覆盖 `perform` 的原始错误。
+  3. **更深层的传输拆除漏洞**：当网络断开或服务端异常关闭（例如 Wi-Fi 断开、sshd 进程被 kill、TCP reset）时，底层 child channel 销毁触发 `handlerRemoved`，产生 `.eof(nil)`。在未收到远端 `exit-status` 或 `exit-signal` 的情况下，原 stream 逻辑将其当成正常流结束直接 `finish()`，导致 `perform` 正常返回，cleanup close 捕获 `alreadyClosed` 后被吸收，最终整个 `withPTY` 返回 `error == nil`，致使 Berth 误判为 `cleanShellExit` 而错误关闭终端 tab。
+
+**Patch 行为**:
+- **事件捕获**：`ExecCommandHandler` 同时捕获 `SSHChannelRequestEvent.ExitStatus` 与 `SSHChannelRequestEvent.ExitSignal`。
+- **状态机判断**：新增 `CommandStreamTerminationState` 结构：
+  - 交互式 PTY/TTY 会话中，只有在收到明确退出证据（`exit-status` 或 `exit-signal`）后，EOF 才能以 clean finish 结束。
+  - 若在未收到任何退出证据时收到 handler 移除引发的 `eof(nil)`，判定为异常传输拆除（Transport Teardown），向流抛出 `ChannelError.eof`，确保上层将其归类为 `transportFailure`。
+- **清理语义**：
+  - `perform` 正常完成后的清理忽略 `ChannelError.alreadyClosed` 和 `ChannelError.eof`，视作正常关闭，保持业务成功结果。
+  - `perform` 抛出异常进入 `catch` 时，清理采用 best-effort（`try? await channel.close()`），确保原始业务错误（如 `tcpShutdown`、`ChannelError.eof` 或其他 I/O 错误）原样向外抛出，绝不被覆盖。
+- **统一生命周期**：抽取 `SSHClient.executeTTYLifecycle`，供 `withPTY`、`withTTY` 以及单元测试直接共用同一生产逻辑。
+- **RFC 4254 规范与退出证据策略 (Exit Evidence Policy)**：
+  - 根据 RFC 4254 §6.10 规定，服务端发送 `exit-status` 属于 `RECOMMENDED`（规范语义等价于 `SHOULD`），而非 `MUST`。因此，部分合法合规的 SSH 服务端实现可能省略 `exit-status`。
+  - Berth 为了防止将网络中断、TCP reset 或 sshd 被 kill 等静默传输拆除误判为正常退出（`cleanShellExit`）导致终端 Tab 误关，**主动采取比协议最低要求更严格的保守 fail-closed 策略**：交互式会话必须收到明确的远端退出证据（`exit-status` 或 `exit-signal`），EOF 才能被解析为正常结束。
+  - 对于合法省略 `exit-status` 的服务端，在连接关闭时将被保守归类为 `transportFailure`，保留终端 Tab 与历史回滚缓冲区，绝不因缺少证据而静默销毁用户工作现场。
+- 源码位置：`vendor/Citadel/Sources/Citadel/TTY/Client/TTY.swift`，以 `[Berth patch]` 注释标记。
+
 ## 升级 Citadel/nio-ssh 时
 本地 vendor 已脱离 SPM 版本管理。若要升级,需重新 vendor 对应版本并重放上述 `[Berth patch]`
 改动(`grep -rn "\[Berth patch\]" vendor/` 可列出全部补丁点)。


### PR DESCRIPTION
## 变更概述

修复 SSH 传输异常时整个终端标签页被当作远端正常 `exit` 而关闭的问题。

- 集中归类用户主动断开、远端 shell 正常退出与传输层异常。
- 网络中断、TCP shutdown、channel EOF/close 以及未知错误均保留终端标签页和 scrollback，并交给既有重连流程处理。
- Citadel PTY/TTY 流同时记录 `exit-status` 与 `exit-signal`，只有存在明确退出证据时才认定交互式 shell 正常结束。
- 统一 PTY/TTY 执行与清理生命周期：清理错误不会覆盖原始业务错误，远端已正常关闭产生的重复 close 错误也不会把正常退出误判为失败。
- 增加结构化的终止原因和传输错误分类日志。

## 问题原因

Citadel 的 child channel 在网络或服务端异常拆除时可能以 `eof(nil)` 结束。旧逻辑会将这种无错误 EOF 当成正常流结束；随后重复关闭 channel 产生的 `alreadyClosed` 又可能被当成 shell 正常退出，最终导致 Berth 销毁终端现场。

另外，旧的错误清理路径可能让 `channel.close()` 的错误覆盖真正的 `tcpShutdown` 或 I/O 错误，使上层无法判断实际断开原因。

## 退出证据策略

本改动采用保守的 fail-closed 策略：交互式 PTY/TTY 只有收到 `exit-status` 或 `exit-signal` 后，EOF 才是正常退出。RFC 4254 对 `exit-status` 的要求是 SHOULD 而不是 MUST，因此少数不发送退出状态的服务端会被归类为传输异常；这种情况下 Berth 会保留终端和历史内容，而不是静默关闭用户现场。

## 影响范围

- `SessionTerminationClassifier`：终止结果与错误类别的统一判断。
- `TerminalSession`：按照分类结果决定关闭、保留或重连。
- vendor Citadel `TTY.swift`：退出证据状态机与不覆盖原始错误的清理语义。
- `vendor/PATCHES.md`：记录可重放的 vendor 补丁及兼容性边界。
- 聚焦回归测试覆盖正常退出、主动取消、TCP/channel/POSIX 错误、退出信号和清理竞态。

## 验证

- `SessionTerminationClassifierTests`：20/20 通过。
- 已检查 `git diff --check`，没有空白或补丁格式问题。
- 本 PR 未验证 iOS；目标为 Berth 当前 macOS PTY/TTY 会话路径。

## PR 顺序

这是拆分系列的第 2 个 PR。建议先合并 #23（测试环境 CloudKit 启动修复），再合并本 PR。本 PR 不包含后续 SFTP pipeline、Finder 拖拽生命周期或下载目标事务代码。
