### PR TITLE
功能：使用有界 SFTP pipeline 加速目录下载

### DIFF
--- a/Berth/Core/SSH/LocalPathComponentValidator.swift
+++ b/Berth/Core/SSH/LocalPathComponentValidator.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Validates untrusted SFTP filenames before they are materialized below a local download root.
+enum LocalPathComponentValidator {
+    enum ValidationError: Error, LocalizedError, Equatable {
+        case emptyComponent
+        case invalidCharacters(component: String)
+        case pathTraversal(component: String)
+        case escapesRoot(candidate: String, root: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .emptyComponent:
+                return String(localized: "远端文件名不能为空。")
+            case .invalidCharacters:
+                return String(localized: "远端文件名包含本地文件系统不支持的字符。")
+            case .pathTraversal:
+                return String(localized: "远端文件名包含不安全的路径分量。")
+            case .escapesRoot:
+                return String(localized: "远端文件的目标路径超出下载目录。")
+            }
+        }
+    }
+
+    static func validateComponent(_ component: String) throws {
+        guard !component.isEmpty else {
+            throw ValidationError.emptyComponent
+        }
+        if component == "." || component == ".." {
+            throw ValidationError.pathTraversal(component: component)
+        }
+        if component.contains("/") || component.contains("\0") {
+            throw ValidationError.invalidCharacters(component: component)
+        }
+        if component.unicodeScalars.contains(where: { $0.value < 32 && $0.value != 9 }) {
+            throw ValidationError.invalidCharacters(component: component)
+        }
+    }
+
+    static func safeURL(
+        in rootDirectory: URL,
+        component: String,
+        isDirectory: Bool = false
+    ) throws -> URL {
+        try validateComponent(component)
+        let candidate = rootDirectory.appendingPathComponent(component, isDirectory: isDirectory)
+        guard isStrictlyContained(candidate: candidate, within: rootDirectory) else {
+            throw ValidationError.escapesRoot(candidate: candidate.path, root: rootDirectory.path)
+        }
+        return candidate
+    }
+
+    static func safeURL(
+        in rootDirectory: URL,
+        components: [String],
+        isDirectory: Bool = false
+    ) throws -> URL {
+        guard !components.isEmpty else {
+            throw ValidationError.emptyComponent
+        }
+        var current = rootDirectory.standardizedFileURL
+        for (index, component) in components.enumerated() {
+            try validateComponent(component)
+            current = current.appendingPathComponent(
+                component,
+                isDirectory: index < components.count - 1 || isDirectory
+            )
+        }
+        guard isStrictlyContained(candidate: current, within: rootDirectory) else {
+            throw ValidationError.escapesRoot(candidate: current.path, root: rootDirectory.path)
+        }
+        return current
+    }
+
+    static func isStrictlyContained(candidate: URL, within root: URL) -> Bool {
+        let rootComponents = root.standardizedFileURL.resolvingSymlinksInPath().pathComponents
+        let candidateComponents = candidate.standardizedFileURL.resolvingSymlinksInPath().pathComponents
+        guard candidateComponents.count > rootComponents.count else { return false }
+        return Array(candidateComponents.prefix(rootComponents.count)) == rootComponents
+    }
+}

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -5,6 +5,40 @@ import Citadel
 import Foundation
 import NIOCore
 
+/// Bridges worker-thread progress to the observable browser state.  Disk and network work never
+/// calls the MainActor directly; updates are already throttled by SFTPDownloadEngine.
+@MainActor
+private final class SFTPDownloadProgressSink {
+    private let progress: Progress?
+    private let apply: (SFTPDownloadEngine.ProgressUpdate) -> Void
+
+    init(
+        progress: Progress?,
+        apply: @escaping (SFTPDownloadEngine.ProgressUpdate) -> Void
+    ) {
+        self.progress = progress
+        self.apply = apply
+    }
+
+    func consume(_ update: SFTPDownloadEngine.ProgressUpdate) {
+        if update.isFinished {
+            // Foundation Progress treats a zero-byte transfer as indeterminate unless it has a
+            // positive total.  Represent the completed empty file as one logical unit so Finder
+            // receives a deterministic 1/1 completion event.
+            let total = max(1, update.totalBytes ?? update.completedBytes)
+            progress?.totalUnitCount = Int64(clamping: total)
+            progress?.completedUnitCount = progress?.totalUnitCount ?? 1
+        } else if let totalBytes = update.totalBytes {
+            progress?.totalUnitCount = Int64(clamping: max(1, totalBytes))
+            progress?.completedUnitCount = min(
+                progress?.totalUnitCount ?? 0,
+                Int64(clamping: update.completedBytes)
+            )
+        }
+        apply(update)
+    }
+}
+
 /// SFTP 文件浏览:复用会话 SSHClient 打开 SFTP,维护当前目录与条目,提供上传/下载/增删改。
 @MainActor
 @Observable
@@ -16,6 +50,9 @@ final class SFTPBrowser {
         let isDirectory: Bool
         let isSymlink: Bool
         let size: UInt64
+        /// `SFTPFileAttributes.size` is optional.  Preserve that distinction so a reported zero
+        /// byte file can skip READ entirely while an unknown-size file still uses EOF fallback.
+        let sizeIsKnown: Bool
         let modified: Date?
         var permissions: UInt32 = 0
         /// 权限低 9 位(rwxrwxrwx)
@@ -28,19 +65,14 @@ final class SFTPBrowser {
         let name: String
         let kind: Kind
         let size: UInt64
-    }
+        let sizeIsKnown: Bool
 
-    struct DownloadTreeFile: Equatable, Sendable {
-        let remotePath: String
-        let relativeComponents: [String]
-        let size: UInt64
-    }
-
-    struct DirectoryDownloadPlan: Equatable, Sendable {
-        var directories: [[String]] = []
-        var files: [DownloadTreeFile] = []
-        var totalBytes: UInt64 = 0
-        var skippedSymlinks = 0
+        init(name: String, kind: Kind, size: UInt64, sizeIsKnown: Bool = true) {
+            self.name = name
+            self.kind = kind
+            self.size = size
+            self.sizeIsKnown = sizeIsKnown
+        }
     }
 
     /// 目录上传扫描时使用的轻量条目(issue #17),与下载侧对称,便于覆盖递归与符号链接边界
@@ -89,14 +121,22 @@ final class SFTPBrowser {
     private(set) var transfers: [ActiveTransfer] = []
 
     private var sftp: SFTPClient?
+    /// One budget per browser/SFTP session.  Concurrent drag and panel downloads share this cap
+    /// instead of creating an independent request window for every file or directory.
+    private let transferBudget: SFTPDownloadEngine.TransferBudget
     private let opener: () async throws -> SFTPClient
     /// 打开后首先落在哪个目录(取该 pane 终端的当前目录);nil 或列不出来时回落 home
     private let initialPath: String?
     /// 面板已关闭:打开中(await opener)被关时,迟到的 client 要立即关掉,不能泄漏子通道
     private var isClosed = false
 
-    init(initialPath: String? = nil, opener: @escaping () async throws -> SFTPClient) {
+    init(
+        initialPath: String? = nil,
+        transferBudget: SFTPDownloadEngine.TransferBudget = .init(),
+        opener: @escaping () async throws -> SFTPClient
+    ) {
         self.initialPath = initialPath
+        self.transferBudget = transferBudget
         self.opener = opener
     }
 
@@ -187,6 +227,7 @@ final class SFTPBrowser {
                     isDirectory: type == .directory,
                     isSymlink: type == .symlink,
                     size: component.attributes.size ?? 0,
+                    sizeIsKnown: component.attributes.size != nil,
                     modified: component.attributes.accessModificationTime?.modificationTime,
                     permissions: component.attributes.permissions ?? 0
                 )
@@ -204,8 +245,8 @@ final class SFTPBrowser {
 
     // MARK: - 传输
 
-    /// 分块传输的块大小(256KB):够大以摊薄往返开销,又够小以更新进度
-    private static let chunkSize = 256 * 1024
+    /// 本地上传的读取块大小(256KB):摊薄往返开销,同时避免整文件读入内存
+    private static let uploadChunkSize = 256 * 1024
 
     private func beginTransfer(_ label: String, progress: Double? = nil) -> UUID {
         let id = UUID()
@@ -272,162 +313,49 @@ final class SFTPBrowser {
             progress: !entry.isDirectory && entry.size > 0 ? 0 : nil
         )
         defer { endTransfer(transferID) }
+        let sink = SFTPDownloadProgressSink(progress: externalProgress) { [weak self] update in
+            guard let self else { return }
+            if let totalBytes = update.totalBytes, totalBytes > 0 {
+                self.setTransfer(transferID, progress: min(
+                    1,
+                    Double(update.completedBytes) / Double(totalBytes)
+                ))
+            } else if update.isFinished {
+                self.setTransfer(transferID, progress: 1)
+            }
+        }
+        let onProgress: @Sendable (SFTPDownloadEngine.ProgressUpdate) async -> Void = { update in
+            await MainActor.run {
+                sink.consume(update)
+            }
+        }
 
         if entry.isDirectory {
-            try await performDirectoryDownload(
-                name: entry.name,
-                remotePath: remotePath,
-                localURL: localURL,
+            _ = try await SFTPDownloadEngine.downloadDirectory(
+                remoteRoot: remotePath,
+                localRoot: localURL,
                 sftp: sftp,
-                transferID: transferID,
-                externalProgress: externalProgress
+                budget: transferBudget,
+                onPlan: { [weak self] plan in
+                    guard let self else { return }
+                    await MainActor.run {
+                        self.setTransfer(transferID, label: plan.skippedSymlinks > 0
+                            ? String(localized: "下载 \(entry.name)…(跳过 \(plan.skippedSymlinks) 个符号链接)")
+                            : String(localized: "下载 \(entry.name)…"))
+                    }
+                },
+                onProgress: onProgress
             )
         } else {
-            externalProgress?.totalUnitCount = entry.size > 0 ? Int64(clamping: entry.size) : 1
-            _ = try await copyRemoteFile(
+            _ = try await SFTPDownloadEngine.downloadFile(
                 remotePath: remotePath,
+                expectedSize: entry.sizeIsKnown ? entry.size : nil,
                 localURL: localURL,
-                sftp: sftp
-            ) { copied in
-                if entry.size > 0 {
-                    setTransfer(transferID, progress: min(1, Double(copied) / Double(entry.size)))
-                    externalProgress?.completedUnitCount = min(
-                        externalProgress?.totalUnitCount ?? 0,
-                        Int64(clamping: copied)
-                    )
-                }
-            }
-            if entry.size == 0 { externalProgress?.completedUnitCount = 1 }
-        }
-    }
-
-    private func performDirectoryDownload(
-        name: String,
-        remotePath: String,
-        localURL: URL,
-        sftp: SFTPClient,
-        transferID: UUID,
-        externalProgress: Progress?
-    ) async throws {
-        let plan = try await Self.makeDirectoryDownloadPlan(remoteRoot: remotePath) { path in
-            let names = try await sftp.listDirectory(atPath: path)
-            return names.flatMap(\.components).compactMap { component in
-                guard component.filename != ".", component.filename != ".." else { return nil }
-                let kind: DownloadTreeEntry.Kind = switch fileType(component) {
-                case .directory: .directory
-                case .symlink: .symlink
-                case .file: .file
-                }
-                return DownloadTreeEntry(
-                    name: component.filename,
-                    kind: kind,
-                    size: component.attributes.size ?? 0
-                )
-            }
-        }
-
-        try Task.checkCancellation()
-        let totalUnits = plan.totalBytes > 0 ? Int64(clamping: plan.totalBytes) : 1
-        externalProgress?.totalUnitCount = totalUnits
-        externalProgress?.completedUnitCount = 0
-        setTransfer(transferID, label: plan.skippedSymlinks > 0
-            ? String(localized: "下载 \(name)…(跳过 \(plan.skippedSymlinks) 个符号链接)")
-            : String(localized: "下载 \(name)…"))
-        setTransfer(transferID, progress: plan.totalBytes > 0 ? 0 : nil)
-
-        for components in plan.directories {
-            try Task.checkCancellation()
-            try FileManager.default.createDirectory(
-                at: localURL.appendingPathComponents(components, directory: true),
-                withIntermediateDirectories: true
+                sftp: sftp,
+                budget: transferBudget,
+                onProgress: onProgress
             )
         }
-
-        var completedBytes: UInt64 = 0
-        for item in plan.files {
-            try Task.checkCancellation()
-            let base = completedBytes
-            let copied = try await copyRemoteFile(
-                remotePath: item.remotePath,
-                localURL: localURL.appendingPathComponents(item.relativeComponents, directory: false),
-                sftp: sftp
-            ) { fileBytes in
-                let aggregate = Self.saturatingAdd(base, fileBytes)
-                if plan.totalBytes > 0 {
-                    setTransfer(transferID, progress: min(1, Double(aggregate) / Double(plan.totalBytes)))
-                    externalProgress?.completedUnitCount = min(totalUnits, Int64(clamping: aggregate))
-                }
-            }
-            completedBytes = Self.saturatingAdd(completedBytes, copied)
-        }
-
-        setTransfer(transferID, progress: 1)
-        externalProgress?.completedUnitCount = totalUnits
-    }
-
-    @discardableResult
-    private func copyRemoteFile(
-        remotePath: String,
-        localURL: URL,
-        sftp: SFTPClient,
-        onProgress: (_ copied: UInt64) -> Void
-    ) async throws -> UInt64 {
-        let file = try await sftp.openFile(filePath: remotePath, flags: .read)
-        defer { Task { try? await file.close() } }
-        guard FileManager.default.createFile(atPath: localURL.path, contents: nil) else {
-            throw CocoaError(.fileWriteUnknown)
-        }
-        let handle = try FileHandle(forWritingTo: localURL)
-        defer { try? handle.close() }
-        return try await Self.copyDownloadChunks(
-            chunkSize: Self.chunkSize,
-            read: { offset, length in
-                let buffer = try await file.read(from: offset, length: length)
-                return Data(buffer.readableBytesView)
-            },
-            write: { data in
-                try handle.write(contentsOf: data)
-            },
-            onProgress: onProgress
-        )
-    }
-
-    /// 先扫描目录树以获得稳定的本地相对路径和总字节。符号链接不跟随,避免循环与
-    /// 把目录树之外的目标意外复制进来。
-    static func makeDirectoryDownloadPlan(
-        remoteRoot: String,
-        list: (_ remotePath: String) async throws -> [DownloadTreeEntry]
-    ) async throws -> DirectoryDownloadPlan {
-        var plan = DirectoryDownloadPlan()
-
-        func scan(remotePath: String, relativeComponents: [String]) async throws {
-            try Task.checkCancellation()
-            plan.directories.append(relativeComponents)
-            for entry in try await list(remotePath) {
-                try Task.checkCancellation()
-                guard entry.name != ".", entry.name != ".." else { continue }
-                let childRemotePath = remotePath == "/"
-                    ? "/\(entry.name)"
-                    : "\(remotePath)/\(entry.name)"
-                let childComponents = relativeComponents + [entry.name]
-                switch entry.kind {
-                case .directory:
-                    try await scan(remotePath: childRemotePath, relativeComponents: childComponents)
-                case .file:
-                    plan.files.append(DownloadTreeFile(
-                        remotePath: childRemotePath,
-                        relativeComponents: childComponents,
-                        size: entry.size
-                    ))
-                    plan.totalBytes = saturatingAdd(plan.totalBytes, entry.size)
-                case .symlink:
-                    plan.skippedSymlinks += 1
-                }
-            }
-        }
-
-        try await scan(remotePath: remoteRoot, relativeComponents: [])
-        return plan
     }
 
     private static func saturatingAdd(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
@@ -534,25 +462,35 @@ final class SFTPBrowser {
         onProgress: (_ copied: UInt64) -> Void = { _ in }
     ) async throws -> UInt64 {
         let handle = try FileHandle(forReadingFrom: localURL)
-        defer { try? handle.close() }
-        let file = try await sftp.openFile(filePath: remotePath, flags: [.write, .create, .truncate])
-        defer { Task { try? await file.close() } }
-
-        var offset: UInt64 = 0
-        while true {
-            try Task.checkCancellation()
-            guard let data = try handle.read(upToCount: chunkSize), !data.isEmpty else { break }
-            var buffer = ByteBufferAllocator().buffer(capacity: data.count)
-            buffer.writeBytes(data)
-            try await file.write(buffer, at: offset)
-            offset += UInt64(data.count)
-            onProgress(offset)
+        do {
+            let file = try await sftp.openFile(filePath: remotePath, flags: [.write, .create, .truncate])
+            do {
+                var offset: UInt64 = 0
+                while true {
+                    try Task.checkCancellation()
+                    guard let data = try handle.read(upToCount: uploadChunkSize), !data.isEmpty else { break }
+                    var buffer = ByteBufferAllocator().buffer(capacity: data.count)
+                    buffer.writeBytes(data)
+                    try await file.write(buffer, at: offset)
+                    offset += UInt64(data.count)
+                    onProgress(offset)
+                }
+                if offset == 0 {
+                    // 空文件也要建出来
+                    try await file.write(ByteBufferAllocator().buffer(capacity: 0), at: 0)
+                }
+                try await file.close()
+                try handle.close()
+                return offset
+            } catch {
+                try? await file.close()
+                try? handle.close()
+                throw error
+            }
+        } catch {
+            try? handle.close()
+            throw error
         }
-        if offset == 0 {
-            // 空文件也要建出来
-            try await file.write(ByteBufferAllocator().buffer(capacity: 0), at: 0)
-        }
-        return offset
     }
 
     /// 递归上传整个目录:扫描出 plan → 建远端目录 → 逐文件流式上传。
@@ -585,27 +523,6 @@ final class SFTPBrowser {
             completedBytes = saturatingAdd(completedBytes, copied)
         }
         onProgress(completedBytes, plan.totalBytes)
-    }
-
-    /// 持续读取直到服务端明确返回 0 字节。SFTP 单次 read 可以合法地返回少于请求长度的
-    /// 数据(常见上限约几十 KB),短读不代表 EOF;把短读当 EOF 会让大文件只下载首个包。
-    @discardableResult
-    static func copyDownloadChunks(
-        chunkSize: Int,
-        read: (_ offset: UInt64, _ length: UInt32) async throws -> Data,
-        write: (_ data: Data) throws -> Void,
-        onProgress: (_ copied: UInt64) -> Void = { _ in }
-    ) async throws -> UInt64 {
-        precondition(chunkSize > 0 && chunkSize <= Int(UInt32.max))
-        var offset: UInt64 = 0
-        while true {
-            try Task.checkCancellation()
-            let data = try await read(offset, UInt32(chunkSize))
-            guard !data.isEmpty else { return offset }
-            try write(data)
-            offset += UInt64(data.count)
-            onProgress(offset)
-        }
     }
 
     /// 上传文件或整个目录(issue #17):目录先扫描再递归,文件流式分块不整读进内存

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -307,6 +307,10 @@ final class SFTPBrowser {
         to localURL: URL,
         externalProgress: Progress?
     ) async throws {
+        // The top-level name is server-controlled too. Validate it before opening a handle or
+        // touching the caller-provided local destination; recursive entries are validated by the
+        // download engine while it builds the directory plan.
+        try LocalPathComponentValidator.validateComponent(entry.name)
         guard let sftp else { throw TransferError.sftpUnavailable }
 
         let remotePath = join(remoteDirectory, entry.name)

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -121,6 +121,7 @@ final class SFTPBrowser {
     private(set) var transfers: [ActiveTransfer] = []
 
     private var sftp: SFTPClient?
+    public let configuration: SFTPTransferConfiguration
     /// One budget per browser/SFTP session.  Concurrent drag and panel downloads share this cap
     /// instead of creating an independent request window for every file or directory.
     private let transferBudget: SFTPDownloadEngine.TransferBudget
@@ -132,11 +133,14 @@ final class SFTPBrowser {
 
     init(
         initialPath: String? = nil,
-        transferBudget: SFTPDownloadEngine.TransferBudget = .init(),
+        configuration: SFTPTransferConfiguration = .init(),
+        transferBudget: SFTPDownloadEngine.TransferBudget? = nil,
         opener: @escaping () async throws -> SFTPClient
     ) {
+        let normalized = configuration.normalized
         self.initialPath = initialPath
-        self.transferBudget = transferBudget
+        self.configuration = normalized
+        self.transferBudget = transferBudget ?? SFTPDownloadEngine.TransferBudget(configuration: normalized)
         self.opener = opener
     }
 
@@ -336,6 +340,7 @@ final class SFTPBrowser {
                 localRoot: localURL,
                 sftp: sftp,
                 budget: transferBudget,
+                configuration: configuration,
                 onPlan: { [weak self] plan in
                     guard let self else { return }
                     await MainActor.run {
@@ -353,6 +358,7 @@ final class SFTPBrowser {
                 localURL: localURL,
                 sftp: sftp,
                 budget: transferBudget,
+                configuration: configuration,
                 onProgress: onProgress
             )
         }

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -834,6 +834,10 @@ final class SFTPBrowser {
     }
 
     private func friendly(_ error: Error) -> String {
+        if let localizedError = error as? LocalizedError,
+           let description = localizedError.errorDescription {
+            return description
+        }
         let raw = String(describing: error)
         if raw.localizedCaseInsensitiveContains("permission") { return String(localized: "权限不足") }
         if raw.localizedCaseInsensitiveContains("noSuchFile") || raw.localizedCaseInsensitiveContains("no such") {

--- a/Berth/Core/SSH/SFTPDownloadEngine.swift
+++ b/Berth/Core/SSH/SFTPDownloadEngine.swift
@@ -299,10 +299,12 @@ enum SFTPDownloadEngine {
     /// only enqueue/coalesce from the engine actor; they never wait for a potentially slow UI
     /// actor. `finish()` closes the stream and awaits that one task, so the final event is ordered
     /// before the public operation returns without creating one unstructured task per READ.
-    private actor ProgressAccumulator {
+    internal actor ProgressAccumulator {
         private var totalBytes: UInt64?
         private var unresolvedFileSizes: Int
-        private var observedKnownTotal: UInt64 = 0
+        /// The effective sum for files whose size is known.  This remains useful while the
+        /// directory total is indeterminate because one or more other files still need FSTAT/EOF.
+        private var knownBytes: UInt64
         private let sink: @Sendable (ProgressUpdate) async -> Void
         private let streamContinuation: AsyncStream<ProgressUpdate>.Continuation
         private let deliveryTask: Task<Void, Never>
@@ -313,10 +315,12 @@ enum SFTPDownloadEngine {
         init(
             totalBytes: UInt64?,
             unresolvedFileSizes: Int,
+            knownBytes: UInt64 = 0,
             sink: @escaping @Sendable (ProgressUpdate) async -> Void
         ) {
             self.totalBytes = totalBytes
             self.unresolvedFileSizes = max(0, unresolvedFileSizes)
+            self.knownBytes = knownBytes
             self.sink = sink
 
             var continuation: AsyncStream<ProgressUpdate>.Continuation!
@@ -340,28 +344,38 @@ enum SFTPDownloadEngine {
         /// directory total, adjust the denominator by the snapshot-vs-listing delta.  If scanning
         /// found an unknown file, publish a total only after every file has an effective size.
         func observeFileSize(listedSize: UInt64?, snapshotSize: UInt64?) {
-            if let totalBytes {
-                if let listedSize, let snapshotSize {
+            if let listedSize {
+                guard let snapshotSize else { return }
+                if let totalBytes {
                     self.totalBytes = adjustedTotal(
                         totalBytes,
                         listedSize: listedSize,
                         snapshotSize: snapshotSize
                     )
-                    enqueueCurrent()
+                } else {
+                    knownBytes = adjustedTotal(
+                        knownBytes,
+                        listedSize: listedSize,
+                        snapshotSize: snapshotSize
+                    )
+                    if unresolvedFileSizes == 0 {
+                        self.totalBytes = knownBytes
+                    }
                 }
+                enqueueCurrent()
                 return
             }
 
             guard unresolvedFileSizes > 0 else { return }
-            guard let effectiveSize = snapshotSize ?? listedSize else {
+            guard let snapshotSize else {
                 // This file will use the EOF-terminated fallback; the directory denominator
                 // remains unknown because no future value can be inferred safely.
                 return
             }
-            observedKnownTotal = saturatingAdd(observedKnownTotal, effectiveSize)
+            knownBytes = saturatingAdd(knownBytes, snapshotSize)
             unresolvedFileSizes -= 1
             if unresolvedFileSizes == 0 {
-                totalBytes = observedKnownTotal
+                totalBytes = knownBytes
             }
             enqueueCurrent()
         }
@@ -610,7 +624,8 @@ enum SFTPDownloadEngine {
         await onPlan(plan)
         let reporter = ProgressAccumulator(
             totalBytes: plan.totalBytes,
-            unresolvedFileSizes: plan.totalBytes == nil ? plan.files.count : 0,
+            unresolvedFileSizes: plan.files.filter { $0.size == nil }.count,
+            knownBytes: plan.files.compactMap(\.size).reduce(0, saturatingAdd),
             sink: onProgress
         )
         await reporter.emitInitial()
@@ -850,6 +865,13 @@ enum SFTPDownloadEngine {
                         write: writeAtOffset,
                         onBytes: onBytes
                     )
+                    // If FSTAT could not provide a size, the EOF-terminated copy is the first
+                    // reliable size observation for this file.  Resolve it before the directory
+                    // progress reporter finishes, otherwise a mixed known/unknown directory can
+                    // remain indeterminate forever.
+                    if expectedSize == nil, snapshotSize == nil {
+                        await onFileSize(nil, copied)
+                    }
                 }
                 try localHandle.close()
                 DebugLog.append("sftp file done name=\(localURL.lastPathComponent) copied=\(copied)")

--- a/Berth/Core/SSH/SFTPDownloadEngine.swift
+++ b/Berth/Core/SSH/SFTPDownloadEngine.swift
@@ -616,12 +616,7 @@ enum SFTPDownloadEngine {
         await reporter.emitInitial()
 
         do {
-            try FileManager.default.createDirectory(at: localRoot, withIntermediateDirectories: true)
-            for components in plan.directories {
-                try Task.checkCancellation()
-                let destination = components.reduce(localRoot) { $0.appendingPathComponent($1, isDirectory: true) }
-                try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
-            }
+            try materializeDirectories(plan.directories, localRoot: localRoot)
 
             try await downloadFiles(
                 plan.files,
@@ -636,6 +631,27 @@ enum SFTPDownloadEngine {
         } catch {
             await reporter.cancelDelivery()
             throw error
+        }
+    }
+
+    /// 真实本地目录物化: 遍历 plan.directories 创建各级目录。
+    /// plan.directories[0] 为 [] (root sentinel, 代表 localRoot 本身), 已在此前由 FileManager 创建, 予以跳过。
+    /// 其余非空 components 按顺序拼接创建。
+    static func materializeDirectories(
+        _ directories: [[String]],
+        localRoot: URL
+    ) throws {
+        try FileManager.default.createDirectory(at: localRoot, withIntermediateDirectories: true)
+        for components in directories {
+            try Task.checkCancellation()
+            if components.isEmpty {
+                // root sentinel; localRoot 已经在此前创建, 跳过 validator 拼接
+                continue
+            }
+            let destination = components.reduce(localRoot) {
+                $0.appendingPathComponent($1, isDirectory: true)
+            }
+            try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
         }
     }
 

--- a/Berth/Core/SSH/SFTPDownloadEngine.swift
+++ b/Berth/Core/SSH/SFTPDownloadEngine.swift
@@ -54,9 +54,18 @@ enum SFTPDownloadEngine {
         let isFinished: Bool
     }
 
-    enum Error: Swift.Error, Equatable {
+    enum Error: Swift.Error, LocalizedError, Equatable {
         case earlyEOF(offset: UInt64, expectedSize: UInt64)
         case invalidReadLength(requested: UInt32, received: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .earlyEOF:
+                return String(localized: "服务器在文件下载完成前提前结束传输。")
+            case .invalidReadLength:
+                return String(localized: "服务器返回了无效的文件数据。")
+            }
+        }
     }
 
     /// Internal coordination primitive for exercising the cancellation boundary between a
@@ -395,7 +404,7 @@ enum SFTPDownloadEngine {
             }
             isClosed = true
             streamContinuation.yield(ProgressUpdate(
-                completedBytes: totalBytes ?? completedBytes,
+                completedBytes: completedBytes,
                 totalBytes: totalBytes,
                 isFinished: true
             ))
@@ -554,6 +563,7 @@ enum SFTPDownloadEngine {
                 for entry in result.entries.sorted(by: { $0.name.localizedStandardCompare($1.name) == .orderedAscending }) {
                     try Task.checkCancellation()
                     guard entry.name != ".", entry.name != ".." else { continue }
+                    guard (try? LocalPathComponentValidator.validateComponent(entry.name)) != nil else { continue }
                     let childPath = appendRemotePath(result.pending.remotePath, entry.name)
                     let childComponents = result.pending.relativeComponents + [entry.name]
                     switch entry.kind {
@@ -663,9 +673,11 @@ enum SFTPDownloadEngine {
                 // root sentinel; localRoot 已经在此前创建, 跳过 validator 拼接
                 continue
             }
-            let destination = components.reduce(localRoot) {
-                $0.appendingPathComponent($1, isDirectory: true)
-            }
+            let destination = try LocalPathComponentValidator.safeURL(
+                in: localRoot,
+                components: components,
+                isDirectory: true
+            )
             try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
         }
     }
@@ -727,9 +739,11 @@ enum SFTPDownloadEngine {
                     let item = files[nextIndex]
                     nextIndex += 1
                     active += 1
-                    let localURL = item.relativeComponents.reduce(localRoot) {
-                        $0.appendingPathComponent($1, isDirectory: false)
-                    }
+                    let localURL = try LocalPathComponentValidator.safeURL(
+                        in: localRoot,
+                        components: item.relativeComponents,
+                        isDirectory: false
+                    )
                     group.addTask {
                         try await downloadOpenedFile(
                             remotePath: item.remotePath,

--- a/Berth/Core/SSH/SFTPDownloadEngine.swift
+++ b/Berth/Core/SSH/SFTPDownloadEngine.swift
@@ -9,48 +9,7 @@ import Foundation
 /// callers do not accidentally create one unbounded pipeline per file.
 enum SFTPDownloadEngine {
 
-    struct Configuration: Sendable, Equatable {
-        /// Start small so a high-latency or conservative server is not overwhelmed during warm-up.
-        var initialPipelineDepth: Int = 2
-        /// Per-file cap.  The global request budget is the hard cap across every file and directory.
-        var maxPipelineDepth: Int = 8
-        var maxConcurrentFiles: Int = 8
-        var maxConcurrentDirectories: Int = 4
-        var maxOutstandingRequests: Int = 64
-        var maxOpenHandles: Int = 16
-        /// SFTP v3 has no portable transfer-size negotiation.  32 KiB is the interoperable fallback.
-        var fallbackChunkSize: Int = 32 * 1024
-
-        init(
-            initialPipelineDepth: Int = 2,
-            maxPipelineDepth: Int = 8,
-            maxConcurrentFiles: Int = 8,
-            maxConcurrentDirectories: Int = 4,
-            maxOutstandingRequests: Int = 64,
-            maxOpenHandles: Int = 16,
-            fallbackChunkSize: Int = 32 * 1024
-        ) {
-            self.initialPipelineDepth = initialPipelineDepth
-            self.maxPipelineDepth = maxPipelineDepth
-            self.maxConcurrentFiles = maxConcurrentFiles
-            self.maxConcurrentDirectories = maxConcurrentDirectories
-            self.maxOutstandingRequests = maxOutstandingRequests
-            self.maxOpenHandles = maxOpenHandles
-            self.fallbackChunkSize = fallbackChunkSize
-        }
-
-        fileprivate var normalized: Self {
-            var value = self
-            value.initialPipelineDepth = max(1, value.initialPipelineDepth)
-            value.maxPipelineDepth = max(value.initialPipelineDepth, value.maxPipelineDepth)
-            value.maxConcurrentFiles = max(1, value.maxConcurrentFiles)
-            value.maxConcurrentDirectories = max(1, value.maxConcurrentDirectories)
-            value.maxOutstandingRequests = max(1, value.maxOutstandingRequests)
-            value.maxOpenHandles = max(1, value.maxOpenHandles)
-            value.fallbackChunkSize = min(Int.UInt32MaxAsInt, max(1, value.fallbackChunkSize))
-            return value
-        }
-    }
+    typealias Configuration = SFTPTransferConfiguration
 
     struct File: Sendable, Equatable {
         let remotePath: String
@@ -298,12 +257,22 @@ enum SFTPDownloadEngine {
     /// through the engine; both semaphores are shared by directory listing, OPEN/FSTAT/READ/CLOSE,
     /// and all concurrently active files.
     actor TransferBudget {
+        nonisolated let configuration: SFTPTransferConfiguration
         private let requests: FIFOPermitSemaphore
         private let handles: FIFOPermitSemaphore
 
-        init(requestLimit: Int = 64, handleLimit: Int = 16) {
-            self.requests = FIFOPermitSemaphore(limit: requestLimit)
-            self.handles = FIFOPermitSemaphore(limit: handleLimit)
+        init(configuration: SFTPTransferConfiguration = .init()) {
+            let normalized = configuration.normalized
+            self.configuration = normalized
+            self.requests = FIFOPermitSemaphore(limit: normalized.requestLimit)
+            self.handles = FIFOPermitSemaphore(limit: normalized.handleLimit)
+        }
+
+        init(requestLimit: Int, handleLimit: Int = 16) {
+            self.init(configuration: SFTPTransferConfiguration(
+                requestLimit: requestLimit,
+                handleLimit: handleLimit
+            ))
         }
 
         func acquireRequest() async throws { try await requests.acquire() }
@@ -603,12 +572,13 @@ enum SFTPDownloadEngine {
         remoteRoot: String,
         localRoot: URL,
         sftp: SFTPClient,
-        budget: TransferBudget,
+        budget: TransferBudget? = nil,
         configuration: Configuration = .init(),
         onPlan: @escaping @Sendable (DirectoryPlan) async -> Void = { _ in },
         onProgress: @escaping @Sendable (ProgressUpdate) async -> Void = { _ in }
     ) async throws -> DirectoryPlan {
         let configuration = configuration.normalized
+        let budget = budget ?? TransferBudget(configuration: configuration)
         let plan = try await makeDirectoryDownloadPlan(
             remoteRoot: remoteRoot,
             budget: budget,
@@ -677,11 +647,12 @@ enum SFTPDownloadEngine {
         expectedSize: UInt64?,
         localURL: URL,
         sftp: SFTPClient,
-        budget: TransferBudget,
+        budget: TransferBudget? = nil,
         configuration: Configuration = .init(),
         onProgress: @escaping @Sendable (ProgressUpdate) async -> Void = { _ in }
     ) async throws -> UInt64 {
         let configuration = configuration.normalized
+        let budget = budget ?? TransferBudget(configuration: configuration)
         let reporter = ProgressAccumulator(
             totalBytes: expectedSize,
             unresolvedFileSizes: expectedSize == nil ? 1 : 0,
@@ -840,6 +811,9 @@ enum SFTPDownloadEngine {
                     try localHandle.seek(toOffset: offset)
                     try localHandle.write(contentsOf: data)
                 }
+                let activeHandles = await budget.currentHandleCount
+                let activeRequests = await budget.currentRequestCount
+                DebugLog.append("sftp file start name=\(localURL.lastPathComponent) size=\(size ?? 0) activeHandles=\(activeHandles) activeRequests=\(activeRequests)")
                 if let size {
                     copied = try await copyKnownSize(
                         expectedSize: size,
@@ -862,8 +836,10 @@ enum SFTPDownloadEngine {
                     )
                 }
                 try localHandle.close()
+                DebugLog.append("sftp file done name=\(localURL.lastPathComponent) copied=\(copied)")
             } catch {
                 try? localHandle.close()
+                DebugLog.append("sftp file failed name=\(localURL.lastPathComponent) error=\(error)")
                 throw error
             }
 
@@ -1001,6 +977,7 @@ enum SFTPDownloadEngine {
                     // Like OpenSSH, ramp up only after a complete response.  Short reads often
                     // indicate a server-side packet cap and should not increase pressure.
                     depth += 1
+                    DebugLog.append("sftp pipeline ramp depth=\(depth) max=\(maximumDepth) offset=\(result.range.offset)")
                 }
                 try schedule()
             }

--- a/Berth/Core/SSH/SFTPDownloadEngine.swift
+++ b/Berth/Core/SSH/SFTPDownloadEngine.swift
@@ -1,0 +1,1054 @@
+import Citadel
+import Foundation
+
+/// The non-UI SFTP download engine.
+///
+/// SFTP is a request/response protocol, but requests are identified independently.  Keeping a
+/// bounded number of READs in flight therefore lets the server and the SSH channel do useful work
+/// while the previous response is being copied to disk.  The engine owns that scheduling policy so
+/// callers do not accidentally create one unbounded pipeline per file.
+enum SFTPDownloadEngine {
+
+    struct Configuration: Sendable, Equatable {
+        /// Start small so a high-latency or conservative server is not overwhelmed during warm-up.
+        var initialPipelineDepth: Int = 2
+        /// Per-file cap.  The global request budget is the hard cap across every file and directory.
+        var maxPipelineDepth: Int = 8
+        var maxConcurrentFiles: Int = 8
+        var maxConcurrentDirectories: Int = 4
+        var maxOutstandingRequests: Int = 64
+        var maxOpenHandles: Int = 16
+        /// SFTP v3 has no portable transfer-size negotiation.  32 KiB is the interoperable fallback.
+        var fallbackChunkSize: Int = 32 * 1024
+
+        init(
+            initialPipelineDepth: Int = 2,
+            maxPipelineDepth: Int = 8,
+            maxConcurrentFiles: Int = 8,
+            maxConcurrentDirectories: Int = 4,
+            maxOutstandingRequests: Int = 64,
+            maxOpenHandles: Int = 16,
+            fallbackChunkSize: Int = 32 * 1024
+        ) {
+            self.initialPipelineDepth = initialPipelineDepth
+            self.maxPipelineDepth = maxPipelineDepth
+            self.maxConcurrentFiles = maxConcurrentFiles
+            self.maxConcurrentDirectories = maxConcurrentDirectories
+            self.maxOutstandingRequests = maxOutstandingRequests
+            self.maxOpenHandles = maxOpenHandles
+            self.fallbackChunkSize = fallbackChunkSize
+        }
+
+        fileprivate var normalized: Self {
+            var value = self
+            value.initialPipelineDepth = max(1, value.initialPipelineDepth)
+            value.maxPipelineDepth = max(value.initialPipelineDepth, value.maxPipelineDepth)
+            value.maxConcurrentFiles = max(1, value.maxConcurrentFiles)
+            value.maxConcurrentDirectories = max(1, value.maxConcurrentDirectories)
+            value.maxOutstandingRequests = max(1, value.maxOutstandingRequests)
+            value.maxOpenHandles = max(1, value.maxOpenHandles)
+            value.fallbackChunkSize = min(Int.UInt32MaxAsInt, max(1, value.fallbackChunkSize))
+            return value
+        }
+    }
+
+    struct File: Sendable, Equatable {
+        let remotePath: String
+        let relativeComponents: [String]
+        let size: UInt64?
+
+        init(remotePath: String, relativeComponents: [String], size: UInt64?) {
+            self.remotePath = remotePath
+            self.relativeComponents = relativeComponents
+            self.size = size
+        }
+    }
+
+    struct DirectoryEntry: Sendable, Equatable {
+        enum Kind: Sendable, Equatable { case directory, file, symlink }
+
+        let name: String
+        let kind: Kind
+        let size: UInt64
+        let sizeIsKnown: Bool
+
+        init(name: String, kind: Kind, size: UInt64 = 0, sizeIsKnown: Bool = true) {
+            self.name = name
+            self.kind = kind
+            self.size = size
+            self.sizeIsKnown = sizeIsKnown
+        }
+    }
+
+    struct DirectoryPlan: Sendable, Equatable {
+        var directories: [[String]] = []
+        var files: [File] = []
+        /// `nil` means at least one file did not expose a size during the directory scan.  A
+        /// partial sum must never be presented as a complete progress denominator.
+        var totalBytes: UInt64? = 0
+        var skippedSymlinks = 0
+    }
+
+    struct ProgressUpdate: Sendable, Equatable {
+        let completedBytes: UInt64
+        let totalBytes: UInt64?
+        let isFinished: Bool
+    }
+
+    enum Error: Swift.Error, Equatable {
+        case earlyEOF(offset: UInt64, expectedSize: UInt64)
+        case invalidReadLength(requested: UInt32, received: Int)
+    }
+
+    /// Internal coordination primitive for exercising the cancellation boundary between a
+    /// queued waiter being granted and that waiter confirming the grant.  It is inert unless a
+    /// test explicitly installs it on a `TransferBudget`.
+    internal actor GrantConfirmationGate {
+        private var didReachGrant = false
+        private var isArmed = true
+        private var isReleased = false
+        private var grantWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiter: CheckedContinuation<Void, Never>?
+
+        /// Wait until the semaphore has resumed its waiter and the waiter is paused immediately
+        /// before `confirm(_:)`.
+        func waitUntilGrant() async {
+            if didReachGrant { return }
+            await withCheckedContinuation { continuation in
+                if didReachGrant {
+                    continuation.resume()
+                } else {
+                    grantWaiters.append(continuation)
+                }
+            }
+        }
+
+        /// Release the waiter paused by `waitUntilConfirmation`.  The gate is one-shot so later
+        /// FIFO waiters follow the normal production path.
+        func release() {
+            isReleased = true
+            releaseWaiter?.resume()
+            releaseWaiter = nil
+        }
+
+        /// Called by the resumed waiter, after `drain()` has marked it granted and resumed its
+        /// continuation, but before cancellation is checked and the grant is confirmed.
+        fileprivate func waitUntilConfirmation() async {
+            guard isArmed else { return }
+            isArmed = false
+            didReachGrant = true
+            let waiters = grantWaiters
+            grantWaiters.removeAll(keepingCapacity: false)
+            for waiter in waiters {
+                waiter.resume()
+            }
+
+            if isReleased { return }
+            await withCheckedContinuation { continuation in
+                if isReleased {
+                    continuation.resume()
+                } else {
+                    releaseWaiter = continuation
+                }
+            }
+        }
+    }
+
+    /// A FIFO, cancellation-aware permit semaphore.  A single instance is owned by one SFTP
+    /// session and shared by every top-level download from that session.  Normal waiters are
+    /// resumed in arrival order; a cancelled waiter is removed without consuming a permit.
+    private actor FIFOPermitSemaphore {
+        private struct Waiter {
+            let id: UInt64
+            let continuation: CheckedContinuation<Void, Swift.Error>
+            var granted = false
+        }
+
+        private let limit: Int
+        private var inUse = 0
+        private var peak = 0
+        private var nextID: UInt64 = 0
+        private var waiters: [UInt64: Waiter] = [:]
+        private var queue: [UInt64] = []
+        private var queueHead = 0
+        private var grantConfirmationGate: GrantConfirmationGate?
+
+        init(limit: Int) {
+            self.limit = max(1, limit)
+        }
+
+        func acquire() async throws {
+            try Task.checkCancellation()
+            if inUse < limit, waiters.isEmpty {
+                reserve()
+                do {
+                    try Task.checkCancellation()
+                } catch {
+                    release()
+                    throw error
+                }
+                return
+            }
+
+            let id = allocateID()
+            do {
+                try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation {
+                        (continuation: CheckedContinuation<Void, Swift.Error>) in
+                        enqueue(Waiter(id: id, continuation: continuation), isCancelled: Task.isCancelled)
+                    }
+                } onCancel: {
+                    Task { await self.cancel(id) }
+                }
+                if let grantConfirmationGate {
+                    await grantConfirmationGate.waitUntilConfirmation()
+                }
+                try Task.checkCancellation()
+                confirm(id)
+            } catch {
+                cancel(id)
+                throw error
+            }
+        }
+
+        /// Cleanup (close) is deliberately uncancellable.  It is called only after the READ task
+        /// group has drained, and must be able to obtain a slot before the remote handle is closed.
+        func acquireForCleanup() async {
+            if inUse < limit, waiters.isEmpty {
+                reserve()
+                return
+            }
+
+            let id = allocateID()
+            _ = try? await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, Swift.Error>) in
+                enqueue(Waiter(id: id, continuation: continuation), isCancelled: false)
+            }
+            waiters.removeValue(forKey: id)
+        }
+
+        func release() {
+            inUse = max(0, inUse - 1)
+            drain()
+        }
+
+        func installGrantConfirmationGate(_ gate: GrantConfirmationGate?) {
+            grantConfirmationGate = gate
+        }
+
+        var currentCount: Int { inUse }
+        var peakCount: Int { peak }
+        var waitingCount: Int { waiters.values.reduce(into: 0) { count, waiter in
+            if !waiter.granted { count += 1 }
+        } }
+
+        private func allocateID() -> UInt64 {
+            defer { nextID &+= 1 }
+            return nextID
+        }
+
+        private func enqueue(_ waiter: Waiter, isCancelled: Bool) {
+            if isCancelled {
+                waiter.continuation.resume(throwing: CancellationError())
+                return
+            }
+            waiters[waiter.id] = waiter
+            queue.append(waiter.id)
+            drain()
+        }
+
+        private func reserve() {
+            inUse += 1
+            peak = max(peak, inUse)
+        }
+
+        private func drain() {
+            while inUse < limit, queueHead < queue.count {
+                let id = queue[queueHead]
+                queueHead += 1
+                guard var waiter = waiters[id], !waiter.granted else { continue }
+                waiter.granted = true
+                waiters[id] = waiter
+                reserve()
+                waiter.continuation.resume()
+            }
+            if queueHead > 64, queueHead * 2 > queue.count {
+                queue.removeFirst(queueHead)
+                queueHead = 0
+            }
+        }
+
+        private func cancel(_ id: UInt64) {
+            guard let waiter = waiters.removeValue(forKey: id) else { return }
+            if waiter.granted {
+                release()
+            } else {
+                waiter.continuation.resume(throwing: CancellationError())
+                drain()
+            }
+        }
+
+        private func confirm(_ id: UInt64) {
+            guard let waiter = waiters[id], waiter.granted else { return }
+            waiters.removeValue(forKey: id)
+        }
+    }
+
+    /// The session-level request and handle budgets.  The actor is intentionally cheap to pass
+    /// through the engine; both semaphores are shared by directory listing, OPEN/FSTAT/READ/CLOSE,
+    /// and all concurrently active files.
+    actor TransferBudget {
+        private let requests: FIFOPermitSemaphore
+        private let handles: FIFOPermitSemaphore
+
+        init(requestLimit: Int = 64, handleLimit: Int = 16) {
+            self.requests = FIFOPermitSemaphore(limit: requestLimit)
+            self.handles = FIFOPermitSemaphore(limit: handleLimit)
+        }
+
+        func acquireRequest() async throws { try await requests.acquire() }
+        func releaseRequest() async { await requests.release() }
+        func acquireRequestForCleanup() async { await requests.acquireForCleanup() }
+        /// Internal coordination hook used only by deterministic cancellation tests.
+        internal func installRequestGrantConfirmationGate(_ gate: GrantConfirmationGate?) async {
+            await requests.installGrantConfirmationGate(gate)
+        }
+        func acquireHandle() async throws { try await handles.acquire() }
+        func releaseHandle() async { await handles.release() }
+
+        var currentRequestCount: Int { get async { await requests.currentCount } }
+        var currentHandleCount: Int { get async { await handles.currentCount } }
+        var peakRequestCount: Int { get async { await requests.peakCount } }
+        var peakHandleCount: Int { get async { await handles.peakCount } }
+        /// Internal coordination hook used by deterministic cancellation tests; it exposes only
+        /// queued request waiters, never the semaphore implementation itself.
+        var requestWaiterCount: Int { get async { await requests.waitingCount } }
+    }
+
+    /// Throttle UI-facing progress to at most approximately ten updates per second.  A single
+    /// AsyncStream consumer performs delivery, with a one-element newest-value buffer.  Producers
+    /// only enqueue/coalesce from the engine actor; they never wait for a potentially slow UI
+    /// actor. `finish()` closes the stream and awaits that one task, so the final event is ordered
+    /// before the public operation returns without creating one unstructured task per READ.
+    private actor ProgressAccumulator {
+        private var totalBytes: UInt64?
+        private var unresolvedFileSizes: Int
+        private var observedKnownTotal: UInt64 = 0
+        private let sink: @Sendable (ProgressUpdate) async -> Void
+        private let streamContinuation: AsyncStream<ProgressUpdate>.Continuation
+        private let deliveryTask: Task<Void, Never>
+        private var completedBytes: UInt64 = 0
+        private var lastEmissionNanos: UInt64 = 0
+        private var isClosed = false
+
+        init(
+            totalBytes: UInt64?,
+            unresolvedFileSizes: Int,
+            sink: @escaping @Sendable (ProgressUpdate) async -> Void
+        ) {
+            self.totalBytes = totalBytes
+            self.unresolvedFileSizes = max(0, unresolvedFileSizes)
+            self.sink = sink
+
+            var continuation: AsyncStream<ProgressUpdate>.Continuation!
+            let stream = AsyncStream<ProgressUpdate>(bufferingPolicy: .bufferingNewest(1)) {
+                continuation = $0
+            }
+            self.streamContinuation = continuation
+            self.deliveryTask = Task {
+                for await update in stream {
+                    await sink(update)
+                }
+            }
+        }
+
+        func emitInitial() {
+            enqueue(ProgressUpdate(completedBytes: 0, totalBytes: totalBytes, isFinished: false))
+            lastEmissionNanos = DispatchTime.now().uptimeNanoseconds
+        }
+
+        /// Record the size observed by FSTAT for one opened file.  For an initially complete
+        /// directory total, adjust the denominator by the snapshot-vs-listing delta.  If scanning
+        /// found an unknown file, publish a total only after every file has an effective size.
+        func observeFileSize(listedSize: UInt64?, snapshotSize: UInt64?) {
+            if let totalBytes {
+                if let listedSize, let snapshotSize {
+                    self.totalBytes = adjustedTotal(
+                        totalBytes,
+                        listedSize: listedSize,
+                        snapshotSize: snapshotSize
+                    )
+                    enqueueCurrent()
+                }
+                return
+            }
+
+            guard unresolvedFileSizes > 0 else { return }
+            guard let effectiveSize = snapshotSize ?? listedSize else {
+                // This file will use the EOF-terminated fallback; the directory denominator
+                // remains unknown because no future value can be inferred safely.
+                return
+            }
+            observedKnownTotal = saturatingAdd(observedKnownTotal, effectiveSize)
+            unresolvedFileSizes -= 1
+            if unresolvedFileSizes == 0 {
+                totalBytes = observedKnownTotal
+            }
+            enqueueCurrent()
+        }
+
+        func add(_ bytes: UInt64) {
+            completedBytes = saturatingAdd(completedBytes, bytes)
+            let now = DispatchTime.now().uptimeNanoseconds
+            guard now &- lastEmissionNanos >= 100_000_000 else { return }
+            enqueueCurrent()
+            lastEmissionNanos = now
+        }
+
+        func finish() async {
+            guard !isClosed else {
+                await deliveryTask.value
+                return
+            }
+            isClosed = true
+            streamContinuation.yield(ProgressUpdate(
+                completedBytes: totalBytes ?? completedBytes,
+                totalBytes: totalBytes,
+                isFinished: true
+            ))
+            streamContinuation.finish()
+            await deliveryTask.value
+        }
+
+        /// End delivery after a failed/cancelled transfer.  There is intentionally no misleading
+        /// `isFinished` progress event, but the already queued UI update is still drained.
+        func cancelDelivery() async {
+            guard !isClosed else {
+                await deliveryTask.value
+                return
+            }
+            isClosed = true
+            streamContinuation.finish()
+            await deliveryTask.value
+        }
+
+        private func enqueueCurrent() {
+            enqueue(ProgressUpdate(
+                completedBytes: completedBytes,
+                totalBytes: totalBytes,
+                isFinished: false
+            ))
+        }
+
+        private func enqueue(_ update: ProgressUpdate) {
+            guard !isClosed else { return }
+            streamContinuation.yield(update)
+        }
+
+        private func adjustedTotal(
+            _ total: UInt64,
+            listedSize: UInt64,
+            snapshotSize: UInt64
+        ) -> UInt64 {
+            if snapshotSize >= listedSize {
+                return saturatingAdd(total, snapshotSize - listedSize)
+            }
+            let decrease = listedSize - snapshotSize
+            return total >= decrease ? total - decrease : 0
+        }
+    }
+
+    private struct ReadRange: Sendable {
+        let offset: UInt64
+        let length: UInt32
+    }
+
+    private struct ReadResult: Sendable {
+        let range: ReadRange
+        let data: Data
+    }
+
+    private static func saturatingAdd(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
+        let (result, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? .max : result
+    }
+
+    private static func withRequest<R: Sendable>(
+        _ budget: TransferBudget,
+        operation: @escaping @Sendable () async throws -> R
+    ) async throws -> R {
+        try await budget.acquireRequest()
+        do {
+            let result = try await operation()
+            await budget.releaseRequest()
+            return result
+        } catch {
+            await budget.releaseRequest()
+            throw error
+        }
+    }
+
+    private static func withCleanupRequest<R: Sendable>(
+        _ budget: TransferBudget,
+        operation: @escaping @Sendable () async throws -> R
+    ) async throws -> R {
+        await budget.acquireRequestForCleanup()
+        do {
+            let result = try await operation()
+            await budget.releaseRequest()
+            return result
+        } catch {
+            await budget.releaseRequest()
+            throw error
+        }
+    }
+
+    private static func withDirectoryList(
+        _ path: String,
+        budget: TransferBudget,
+        list: @escaping @Sendable (String) async throws -> [DirectoryEntry]
+    ) async throws -> [DirectoryEntry] {
+        // listDirectory internally owns an OPENDIR handle until the call returns.  Holding a handle
+        // permit across the whole operation makes that lifetime part of the same global budget.
+        try await budget.acquireHandle()
+        do {
+            let result = try await withRequest(budget) { try await list(path) }
+            await budget.releaseHandle()
+            return result
+        } catch {
+            await budget.releaseHandle()
+            throw error
+        }
+    }
+
+    /// Scan a remote tree breadth-first with a bounded number of concurrent OPENDIR operations.
+    /// Results are sorted before being added to the plan so completion order cannot change local
+    /// layout or make tests/non-deterministic retries differ.
+    static func makeDirectoryDownloadPlan(
+        remoteRoot: String,
+        budget: TransferBudget,
+        configuration: Configuration = .init(),
+        list: @escaping @Sendable (String) async throws -> [DirectoryEntry]
+    ) async throws -> DirectoryPlan {
+        let configuration = configuration.normalized
+
+        struct PendingDirectory: Sendable {
+            let remotePath: String
+            let relativeComponents: [String]
+        }
+        struct ListedDirectory: Sendable {
+            let pending: PendingDirectory
+            let entries: [DirectoryEntry]
+        }
+
+        var pending = [PendingDirectory(remotePath: remoteRoot, relativeComponents: [])]
+        var plan = DirectoryPlan()
+
+        while !pending.isEmpty {
+            let batchCount = min(configuration.maxConcurrentDirectories, pending.count)
+            let batch = Array(pending.prefix(batchCount))
+            pending.removeFirst(batchCount)
+
+            var listed: [ListedDirectory] = []
+            try await withThrowingTaskGroup(of: ListedDirectory.self) { group in
+                for item in batch {
+                    group.addTask {
+                        let entries = try await withDirectoryList(item.remotePath, budget: budget, list: list)
+                        return ListedDirectory(pending: item, entries: entries)
+                    }
+                }
+                while let result = try await group.next() {
+                    listed.append(result)
+                }
+            }
+
+            listed.sort {
+                $0.pending.relativeComponents.map { $0 }.joined(separator: "/")
+                    < $1.pending.relativeComponents.map { $0 }.joined(separator: "/")
+            }
+            for result in listed {
+                plan.directories.append(result.pending.relativeComponents)
+                for entry in result.entries.sorted(by: { $0.name.localizedStandardCompare($1.name) == .orderedAscending }) {
+                    try Task.checkCancellation()
+                    guard entry.name != ".", entry.name != ".." else { continue }
+                    let childPath = appendRemotePath(result.pending.remotePath, entry.name)
+                    let childComponents = result.pending.relativeComponents + [entry.name]
+                    switch entry.kind {
+                    case .directory:
+                        pending.append(PendingDirectory(remotePath: childPath, relativeComponents: childComponents))
+                    case .file:
+                        plan.files.append(File(
+                            remotePath: childPath,
+                            relativeComponents: childComponents,
+                            size: entry.sizeIsKnown ? entry.size : nil
+                        ))
+                        if entry.sizeIsKnown, let totalBytes = plan.totalBytes {
+                            plan.totalBytes = saturatingAdd(totalBytes, entry.size)
+                        } else if !entry.sizeIsKnown {
+                            plan.totalBytes = nil
+                        }
+                    case .symlink:
+                        plan.skippedSymlinks += 1
+                    }
+                }
+            }
+        }
+        return plan
+    }
+
+    /// Download a tree after scanning it.  At most maxConcurrentFiles files are active, while the
+    /// shared budget caps the aggregate READ/OPEN/CLOSE operations across those files.
+    @discardableResult
+    static func downloadDirectory(
+        remoteRoot: String,
+        localRoot: URL,
+        sftp: SFTPClient,
+        budget: TransferBudget,
+        configuration: Configuration = .init(),
+        onPlan: @escaping @Sendable (DirectoryPlan) async -> Void = { _ in },
+        onProgress: @escaping @Sendable (ProgressUpdate) async -> Void = { _ in }
+    ) async throws -> DirectoryPlan {
+        let configuration = configuration.normalized
+        let plan = try await makeDirectoryDownloadPlan(
+            remoteRoot: remoteRoot,
+            budget: budget,
+            configuration: configuration
+        ) { path in
+            let names = try await sftp.listDirectory(atPath: path)
+            return names.flatMap(\.components).compactMap { component in
+                guard component.filename != ".", component.filename != ".." else { return nil }
+                let kind: DirectoryEntry.Kind
+                if let permissions = component.attributes.permissions {
+                    switch permissions & 0o170000 {
+                    case 0o040000: kind = .directory
+                    case 0o120000: kind = .symlink
+                    default: kind = .file
+                    }
+                } else {
+                    kind = component.longname.first == "d" ? .directory
+                        : (component.longname.first == "l" ? .symlink : .file)
+                }
+                return DirectoryEntry(
+                    name: component.filename,
+                    kind: kind,
+                    size: component.attributes.size ?? 0,
+                    sizeIsKnown: component.attributes.size != nil
+                )
+            }
+        }
+
+        await onPlan(plan)
+        let reporter = ProgressAccumulator(
+            totalBytes: plan.totalBytes,
+            unresolvedFileSizes: plan.totalBytes == nil ? plan.files.count : 0,
+            sink: onProgress
+        )
+        await reporter.emitInitial()
+
+        do {
+            try FileManager.default.createDirectory(at: localRoot, withIntermediateDirectories: true)
+            for components in plan.directories {
+                try Task.checkCancellation()
+                let destination = components.reduce(localRoot) { $0.appendingPathComponent($1, isDirectory: true) }
+                try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+            }
+
+            try await downloadFiles(
+                plan.files,
+                localRoot: localRoot,
+                sftp: sftp,
+                configuration: configuration,
+                budget: budget,
+                reporter: reporter
+            )
+            await reporter.finish()
+            return plan
+        } catch {
+            await reporter.cancelDelivery()
+            throw error
+        }
+    }
+
+    /// Download one file.  A known size uses the pipelined path and never asks for an extra EOF
+    /// packet.  Unknown-size files retain the conservative sequential EOF-terminated path.
+    @discardableResult
+    static func downloadFile(
+        remotePath: String,
+        expectedSize: UInt64?,
+        localURL: URL,
+        sftp: SFTPClient,
+        budget: TransferBudget,
+        configuration: Configuration = .init(),
+        onProgress: @escaping @Sendable (ProgressUpdate) async -> Void = { _ in }
+    ) async throws -> UInt64 {
+        let configuration = configuration.normalized
+        let reporter = ProgressAccumulator(
+            totalBytes: expectedSize,
+            unresolvedFileSizes: expectedSize == nil ? 1 : 0,
+            sink: onProgress
+        )
+        await reporter.emitInitial()
+        do {
+            let copied = try await downloadOpenedFile(
+                remotePath: remotePath,
+                expectedSize: expectedSize,
+                localURL: localURL,
+                sftp: sftp,
+                configuration: configuration,
+                budget: budget,
+                reporter: reporter
+            )
+            await reporter.finish()
+            return copied
+        } catch {
+            await reporter.cancelDelivery()
+            throw error
+        }
+    }
+
+    private static func downloadFiles(
+        _ files: [File],
+        localRoot: URL,
+        sftp: SFTPClient,
+        configuration: Configuration,
+        budget: TransferBudget,
+        reporter: ProgressAccumulator
+    ) async throws {
+        guard !files.isEmpty else { return }
+        try await withThrowingTaskGroup(of: UInt64.self) { group in
+            var nextIndex = 0
+            var active = 0
+
+            while nextIndex < files.count || active > 0 {
+                while active < configuration.maxConcurrentFiles, nextIndex < files.count {
+                    try Task.checkCancellation()
+                    let item = files[nextIndex]
+                    nextIndex += 1
+                    active += 1
+                    let localURL = item.relativeComponents.reduce(localRoot) {
+                        $0.appendingPathComponent($1, isDirectory: false)
+                    }
+                    group.addTask {
+                        try await downloadOpenedFile(
+                            remotePath: item.remotePath,
+                            expectedSize: item.size,
+                            localURL: localURL,
+                            sftp: sftp,
+                            configuration: configuration,
+                            budget: budget,
+                            reporter: reporter
+                        )
+                    }
+                }
+
+                if active > 0 {
+                    _ = try await group.next()
+                    active -= 1
+                }
+            }
+        }
+    }
+
+    private static func downloadOpenedFile(
+        remotePath: String,
+        expectedSize: UInt64?,
+        localURL: URL,
+        sftp: SFTPClient,
+        configuration: Configuration,
+        budget: TransferBudget,
+        reporter: ProgressAccumulator
+    ) async throws -> UInt64 {
+        return try await downloadOpenedFileLifecycle(
+            expectedSize: expectedSize,
+            localURL: localURL,
+            chunkSize: readChunkSize(for: sftp, configuration: configuration),
+            configuration: configuration,
+            budget: budget,
+            open: {
+                try await sftp.openFile(filePath: remotePath, flags: .read)
+            },
+            snapshot: { file in
+                try await file.readAttributes().size
+            },
+            read: { file, offset, length in
+                let buffer = try await file.read(from: offset, length: length)
+                return Data(buffer.readableBytesView)
+            },
+            close: { file in
+                try await file.close()
+            },
+            onFileSize: { listedSize, snapshotSize in
+                await reporter.observeFileSize(listedSize: listedSize, snapshotSize: snapshotSize)
+            },
+            onBytes: { bytes in await reporter.add(bytes) }
+        )
+    }
+
+    /// The resource-lifecycle seam used by production and deterministic tests.  The SFTP-specific
+    /// adapter above supplies OPEN/FSTAT/READ/CLOSE; this function owns the ordering and budgets so
+    /// a cancelled transfer cannot close an open handle until every in-flight READ has drained.
+    static func downloadOpenedFileLifecycle<RemoteHandle: Sendable>(
+        expectedSize: UInt64?,
+        localURL: URL,
+        chunkSize: UInt32,
+        configuration: Configuration = .init(),
+        budget: TransferBudget,
+        open: @escaping @Sendable () async throws -> RemoteHandle,
+        snapshot: @escaping @Sendable (RemoteHandle) async throws -> UInt64?,
+        read: @escaping @Sendable (RemoteHandle, UInt64, UInt32) async throws -> Data,
+        close: @escaping @Sendable (RemoteHandle) async throws -> Void,
+        onFileSize: @escaping @Sendable (UInt64?, UInt64?) async -> Void = { _, _ in },
+        onBytes: @escaping @Sendable (UInt64) async -> Void = { _ in }
+    ) async throws -> UInt64 {
+        let configuration = configuration.normalized
+        try Task.checkCancellation()
+        try await budget.acquireHandle()
+
+        var openedHandle: RemoteHandle? = nil
+        var remoteClosed = false
+        do {
+            let handle = try await withRequest(budget) {
+                try await open()
+            }
+            openedHandle = handle
+
+            // FSTAT happens after OPEN and before any READ scheduling.  If the listing supplied a
+            // hint, it remains only as a fallback for a server that omits the size attribute.
+            try Task.checkCancellation()
+            let snapshotSize = try await withRequest(budget) {
+                try await snapshot(handle)
+            }
+            let size = snapshotSize ?? expectedSize
+            await onFileSize(expectedSize, snapshotSize)
+
+            try Task.checkCancellation()
+            try FileManager.default.createDirectory(
+                at: localURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if !FileManager.default.createFile(atPath: localURL.path, contents: nil) {
+                throw CocoaError(.fileWriteUnknown)
+            }
+            let localHandle = try FileHandle(forWritingTo: localURL)
+            let copied: UInt64
+            do {
+                try localHandle.truncate(atOffset: 0)
+                let readAtOffset: @Sendable (UInt64, UInt32) async throws -> Data = { offset, length in
+                    try await read(handle, offset, length)
+                }
+                let writeAtOffset: @Sendable (Data, UInt64) throws -> Void = { data, offset in
+                    try localHandle.seek(toOffset: offset)
+                    try localHandle.write(contentsOf: data)
+                }
+                if let size {
+                    copied = try await copyKnownSize(
+                        expectedSize: size,
+                        chunkSize: chunkSize,
+                        initialPipelineDepth: configuration.initialPipelineDepth,
+                        maxPipelineDepth: configuration.maxPipelineDepth,
+                        budget: budget,
+                        read: readAtOffset,
+                        write: writeAtOffset,
+                        onBytes: onBytes
+                    )
+                    try localHandle.truncate(atOffset: size)
+                } else {
+                    copied = try await copyUnknownSize(
+                        chunkSize: chunkSize,
+                        budget: budget,
+                        read: readAtOffset,
+                        write: writeAtOffset,
+                        onBytes: onBytes
+                    )
+                }
+                try localHandle.close()
+            } catch {
+                try? localHandle.close()
+                throw error
+            }
+
+            // copyKnownSize/copyUnknownSize have drained their structured task groups here.  The
+            // remote CLOSE is therefore the first request after every in-flight READ completes.
+            try await withCleanupRequest(budget) {
+                try await close(handle)
+            }
+            remoteClosed = true
+            await budget.releaseHandle()
+            return copied
+        } catch {
+            if let openedHandle, !remoteClosed {
+                // Cleanup deliberately obtains a non-cancellable request slot.  The close is
+                // awaited before this lifecycle function releases the handle permit or rethrows.
+                try? await withCleanupRequest(budget) {
+                    try await close(openedHandle)
+                }
+            }
+            await budget.releaseHandle()
+            throw error
+        }
+    }
+
+    private static func readChunkSize(for sftp: SFTPClient, configuration: Configuration) -> UInt32 {
+        // limits@openssh.com is deliberately left for a follow-up vendor change.  Keep the
+        // interoperable OpenSSH fallback here and make it configurable only for deterministic tests.
+        _ = sftp
+        return UInt32(clamping: max(1, configuration.fallbackChunkSize))
+    }
+
+    /// Pipeline a known-size file.  Responses are intentionally consumed in completion order and
+    /// written at their recorded offsets, so a server may legally return DATA packets out of order.
+    /// A short DATA response queues the unfilled tail of that range; only an empty response before
+    /// the expected size is treated as an early EOF error.
+    @discardableResult
+    static func copyKnownSize(
+        expectedSize: UInt64,
+        chunkSize: UInt32,
+        initialPipelineDepth: Int = 2,
+        maxPipelineDepth: Int = 8,
+        budget: TransferBudget? = nil,
+        read: @escaping @Sendable (UInt64, UInt32) async throws -> Data,
+        write: @escaping @Sendable (Data, UInt64) throws -> Void,
+        onBytes: @escaping @Sendable (UInt64) async -> Void = { _ in }
+    ) async throws -> UInt64 {
+        guard expectedSize > 0 else { return 0 }
+        precondition(chunkSize > 0)
+        let initialDepth = max(1, initialPipelineDepth)
+        let maximumDepth = max(initialDepth, maxPipelineDepth)
+        // Only the active window and short-read remainders are retained.  In particular, do not
+        // materialize one ReadRange per chunk: a multi-terabyte file must have the same scheduler
+        // memory footprint as a small file.
+        var nextOffset: UInt64 = 0
+        var pendingRemainders: [ReadRange] = []
+        var inFlight = 0
+        var depth = initialDepth
+        // Servers commonly cap a DATA response below the requested length.  Once that is
+        // observed, use the returned size as the upper bound for future requests.  Keep a small
+        // floor so a pathological one-byte short read cannot collapse the pipeline into needless
+        // single-byte requests; outstanding ranges still complete at their original offsets.
+        let minimumChunkSize = max(1, min(chunkSize / 4, UInt32(4 * 1024)))
+        var effectiveChunkSize = chunkSize
+        var copied: UInt64 = 0
+
+        try await withThrowingTaskGroup(of: ReadResult.self) { group in
+            func nextRange() -> ReadRange? {
+                if let remainder = pendingRemainders.popLast() {
+                    let length = min(effectiveChunkSize, remainder.length)
+                    if length < remainder.length {
+                        pendingRemainders.append(ReadRange(
+                            offset: remainder.offset + UInt64(length),
+                            length: remainder.length - length
+                        ))
+                    }
+                    return ReadRange(offset: remainder.offset, length: length)
+                }
+                guard nextOffset < expectedSize else { return nil }
+                let remaining = expectedSize - nextOffset
+                let length = UInt32(min(UInt64(effectiveChunkSize), remaining))
+                let range = ReadRange(offset: nextOffset, length: length)
+                nextOffset += UInt64(length)
+                return range
+            }
+
+            func schedule() throws {
+                while inFlight < depth {
+                    try Task.checkCancellation()
+                    guard let range = nextRange() else { return }
+                    inFlight += 1
+                    group.addTask {
+                        let data: Data
+                        if let budget {
+                            data = try await withRequest(budget) {
+                                try await read(range.offset, range.length)
+                            }
+                        } else {
+                            data = try await read(range.offset, range.length)
+                        }
+                        return ReadResult(range: range, data: data)
+                    }
+                }
+            }
+
+            try schedule()
+            while inFlight > 0 {
+                guard let result = try await group.next() else { break }
+                inFlight -= 1
+                let received = result.data.count
+                guard received > 0 else {
+                    throw Error.earlyEOF(offset: result.range.offset, expectedSize: expectedSize)
+                }
+                guard received <= Int(result.range.length) else {
+                    throw Error.invalidReadLength(requested: result.range.length, received: received)
+                }
+
+                try write(result.data, result.range.offset)
+                copied = saturatingAdd(copied, UInt64(received))
+                await onBytes(UInt64(received))
+
+                if received < Int(result.range.length) {
+                    let receivedLength = UInt32(received)
+                    effectiveChunkSize = max(
+                        minimumChunkSize,
+                        min(effectiveChunkSize, max(minimumChunkSize, receivedLength))
+                    )
+                    // Keep one interval for the missing tail; nextRange() splits it lazily at the
+                    // current effective size.  Thus the remainder queue stays proportional to the
+                    // active window even when every response is short.
+                    pendingRemainders.append(ReadRange(
+                        offset: result.range.offset + UInt64(received),
+                        length: result.range.length - receivedLength
+                    ))
+                } else if depth < maximumDepth {
+                    // Like OpenSSH, ramp up only after a complete response.  Short reads often
+                    // indicate a server-side packet cap and should not increase pressure.
+                    depth += 1
+                }
+                try schedule()
+            }
+        }
+        guard copied == expectedSize else {
+            throw Error.earlyEOF(offset: copied, expectedSize: expectedSize)
+        }
+        return copied
+    }
+
+    /// Sequential unknown-size fallback.  A short non-empty read is data, not EOF; only an empty
+    /// DATA response marks completion.
+    @discardableResult
+    static func copyUnknownSize(
+        chunkSize: UInt32,
+        budget: TransferBudget? = nil,
+        read: @escaping @Sendable (UInt64, UInt32) async throws -> Data,
+        write: @escaping @Sendable (Data, UInt64) throws -> Void,
+        onBytes: @escaping @Sendable (UInt64) async -> Void = { _ in }
+    ) async throws -> UInt64 {
+        precondition(chunkSize > 0)
+        var offset: UInt64 = 0
+        while true {
+            try Task.checkCancellation()
+            let readOffset = offset
+            let data: Data
+            if let budget {
+                data = try await withRequest(budget) {
+                    try await read(readOffset, chunkSize)
+                }
+            } else {
+                data = try await read(readOffset, chunkSize)
+            }
+            guard !data.isEmpty else { return offset }
+            guard data.count <= Int(chunkSize) else {
+                throw Error.invalidReadLength(requested: chunkSize, received: data.count)
+            }
+            try write(data, offset)
+            offset = saturatingAdd(offset, UInt64(data.count))
+            await onBytes(UInt64(data.count))
+        }
+    }
+
+    private static func appendRemotePath(_ base: String, _ name: String) -> String {
+        base == "/" ? "/\(name)" : "\(base)/\(name)"
+    }
+}
+
+private extension Int {
+    static var UInt32MaxAsInt: Int { Int(UInt32.max) }
+}

--- a/Berth/Core/SSH/SFTPTransferConfiguration.swift
+++ b/Berth/Core/SSH/SFTPTransferConfiguration.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// 统一的 SFTP 传输并发与管线配置单一数据源。
+/// 既控制单个文件的 READ pipeline 深度与并发文件数，
+/// 也直接决定全局 TransferBudget 的 requestLimit 与 handleLimit。
+public struct SFTPTransferConfiguration: Sendable, Equatable {
+    /// 初始单文件 pipeline 深度。低延迟/保守服务器在热身阶段避免并发过载。
+    public var initialPipelineDepth: Int
+    /// 单文件 pipeline 深度上限。
+    public var maxPipelineDepth: Int
+    /// 同时并发下载的文件数。
+    public var maxConcurrentFiles: Int
+    /// 目录扫描时并发列举目录数。
+    public var maxConcurrentDirectories: Int
+    /// 全局未完成请求硬上限 (对应 TransferBudget.requests limit)。
+    public var requestLimit: Int
+    /// 全局同时打开句柄硬上限 (对应 TransferBudget.handles limit)。
+    public var handleLimit: Int
+    /// SFTP v3 块大小回落 (字节)。默认 32 KiB。
+    public var fallbackChunkSize: Int
+
+    /// 兼容旧属性名
+    public var maxOutstandingRequests: Int {
+        get { requestLimit }
+        set { requestLimit = newValue }
+    }
+    public var maxOpenHandles: Int {
+        get { handleLimit }
+        set { handleLimit = newValue }
+    }
+
+    public init(
+        initialPipelineDepth: Int = 2,
+        maxPipelineDepth: Int = 8,
+        maxConcurrentFiles: Int = 8,
+        maxConcurrentDirectories: Int = 4,
+        requestLimit: Int = 64,
+        handleLimit: Int = 16,
+        fallbackChunkSize: Int = 32 * 1024
+    ) {
+        // 允许通过环境变量对生产与验收环境做 A/B 调优与快速降载
+        let env = ProcessInfo.processInfo.environment
+        let envFiles = env["BERTH_SFTP_MAX_CONCURRENT_FILES"].flatMap(Int.init)
+        let envInitPipe = env["BERTH_SFTP_INITIAL_PIPELINE_DEPTH"].flatMap(Int.init)
+        let envMaxPipe = env["BERTH_SFTP_MAX_PIPELINE_DEPTH"].flatMap(Int.init)
+        let envReqLimit = env["BERTH_SFTP_REQUEST_LIMIT"].flatMap(Int.init)
+        let envHandleLimit = env["BERTH_SFTP_HANDLE_LIMIT"].flatMap(Int.init)
+
+        self.initialPipelineDepth = envInitPipe ?? initialPipelineDepth
+        self.maxPipelineDepth = envMaxPipe ?? maxPipelineDepth
+        self.maxConcurrentFiles = envFiles ?? maxConcurrentFiles
+        self.maxConcurrentDirectories = maxConcurrentDirectories
+        self.requestLimit = envReqLimit ?? requestLimit
+        self.handleLimit = envHandleLimit ?? handleLimit
+        self.fallbackChunkSize = fallbackChunkSize
+    }
+
+    public var normalized: Self {
+        var value = self
+        value.initialPipelineDepth = max(1, value.initialPipelineDepth)
+        value.maxPipelineDepth = max(value.initialPipelineDepth, value.maxPipelineDepth)
+        value.maxConcurrentFiles = max(1, value.maxConcurrentFiles)
+        value.maxConcurrentDirectories = max(1, value.maxConcurrentDirectories)
+        value.requestLimit = max(1, value.requestLimit)
+        value.handleLimit = max(1, value.handleLimit)
+        value.fallbackChunkSize = min(Int.max, max(1, value.fallbackChunkSize))
+        return value
+    }
+}

--- a/Berth/Resources/Localizable.xcstrings
+++ b/Berth/Resources/Localizable.xcstrings
@@ -5437,6 +5437,26 @@
         }
       }
     },
+    "服务器在文件下载完成前提前结束传输。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The server ended the transfer before the file download completed."
+          }
+        }
+      }
+    },
+    "服务器返回了无效的文件数据。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The server returned invalid file data."
+          }
+        }
+      }
+    },
     "服务器在握手阶段关闭了连接:多半是本机 IP 触发了 %@ 的连接频率限制": {
       "localizations": {
         "en": {
@@ -8023,6 +8043,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "Remote %@:%@ → %@:%@"
+          }
+        }
+      }
+    },
+    "远端文件名不能为空。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The remote filename cannot be empty."
+          }
+        }
+      }
+    },
+    "远端文件名包含不安全的路径分量。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The remote filename contains an unsafe path component."
+          }
+        }
+      }
+    },
+    "远端文件名包含本地文件系统不支持的字符。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The remote filename contains characters unsupported by the local file system."
+          }
+        }
+      }
+    },
+    "远端文件的目标路径超出下载目录。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The destination path for the remote file is outside the download directory."
           }
         }
       }

--- a/BerthTests/LocalPathComponentValidatorTests.swift
+++ b/BerthTests/LocalPathComponentValidatorTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import Berth
+
+final class LocalPathComponentValidatorTests: XCTestCase {
+    private var tempDirectoryURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ValidatorTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDirectoryURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDirectoryURL {
+            try? FileManager.default.removeItem(at: tempDirectoryURL)
+        }
+        super.tearDown()
+    }
+
+    func testValidComponentPasses() throws {
+        let names = ["file.txt", "My Document (1).docx", "中文文件名.txt", ".hiddenfile"]
+        for name in names {
+            XCTAssertNoThrow(try LocalPathComponentValidator.validateComponent(name))
+        }
+    }
+
+    func testBackslashInFilenameIsValid() throws {
+        let name = "foo\\bar.txt"
+        XCTAssertNoThrow(try LocalPathComponentValidator.validateComponent(name))
+        XCTAssertEqual(
+            try LocalPathComponentValidator.safeURL(in: tempDirectoryURL, component: name).lastPathComponent,
+            name
+        )
+    }
+
+    func testRejectsEmptyDotSlashNullAndControls() {
+        for name in ["", ".", "..", "foo/bar", "../passwd", "/absolute", "file\0name", "file\nname"] {
+            XCTAssertThrowsError(try LocalPathComponentValidator.validateComponent(name), name)
+        }
+    }
+
+    func testSafeURLStaysStrictlyBelowRoot() throws {
+        let safe = try LocalPathComponentValidator.safeURL(
+            in: tempDirectoryURL,
+            components: ["subdir", "nested", "file.log"]
+        )
+        XCTAssertTrue(LocalPathComponentValidator.isStrictlyContained(candidate: safe, within: tempDirectoryURL))
+    }
+
+    func testPrefixCollisionAndEqualPathAreNotContained() {
+        let root = tempDirectoryURL.appendingPathComponent("target", isDirectory: true)
+        let collision = tempDirectoryURL.appendingPathComponent("target2/file.txt")
+        XCTAssertFalse(LocalPathComponentValidator.isStrictlyContained(candidate: collision, within: root))
+        XCTAssertFalse(LocalPathComponentValidator.isStrictlyContained(candidate: root, within: root))
+    }
+}

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -679,4 +679,55 @@ final class SFTPBrowserTests: XCTestCase {
         XCTAssertEqual(finalRequestCount, 0)
         XCTAssertEqual(finalHandleCount, 0)
     }
+
+    func testTransferConfigurationNormalizationAndBudgetSingleSource() async {
+        let customConfig = SFTPTransferConfiguration(
+            initialPipelineDepth: 4,
+            maxPipelineDepth: 16,
+            maxConcurrentFiles: 2,
+            maxConcurrentDirectories: 1,
+            requestLimit: 32,
+            handleLimit: 8
+        )
+        let budget = SFTPDownloadEngine.TransferBudget(configuration: customConfig)
+        XCTAssertEqual(budget.configuration.requestLimit, 32)
+        XCTAssertEqual(budget.configuration.handleLimit, 8)
+        XCTAssertEqual(budget.configuration.maxConcurrentFiles, 2)
+        XCTAssertEqual(budget.configuration.initialPipelineDepth, 4)
+        XCTAssertEqual(budget.configuration.maxPipelineDepth, 16)
+
+        // Verify normalization clamps non-positive values
+        let invalidConfig = SFTPTransferConfiguration(
+            initialPipelineDepth: 0,
+            maxPipelineDepth: -5,
+            maxConcurrentFiles: 0,
+            maxConcurrentDirectories: -1,
+            requestLimit: 0,
+            handleLimit: -2
+        )
+        let normalized = invalidConfig.normalized
+        XCTAssertEqual(normalized.initialPipelineDepth, 1)
+        XCTAssertEqual(normalized.maxPipelineDepth, 1)
+        XCTAssertEqual(normalized.maxConcurrentFiles, 1)
+        XCTAssertEqual(normalized.maxConcurrentDirectories, 1)
+        XCTAssertEqual(normalized.requestLimit, 1)
+        XCTAssertEqual(normalized.handleLimit, 1)
+    }
+
+    @MainActor
+    func testSFTPBrowserInitializesMatchingBudgetFromConfiguration() {
+        let config = SFTPTransferConfiguration(
+            initialPipelineDepth: 2,
+            maxPipelineDepth: 4,
+            maxConcurrentFiles: 4,
+            requestLimit: 16,
+            handleLimit: 4
+        )
+        let browser = SFTPBrowser(configuration: config) {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        XCTAssertEqual(browser.configuration.requestLimit, 16)
+        XCTAssertEqual(browser.configuration.handleLimit, 4)
+        XCTAssertEqual(browser.configuration.maxConcurrentFiles, 4)
+    }
 }

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -814,4 +814,32 @@ final class SFTPBrowserTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: tempRoot.appendingPathComponent("subfolder").path))
     }
 
+    func testDirectoryMaterializationRejectsMaliciousTraversal() {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MaterializeMaliciousTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        XCTAssertThrowsError(
+            try SFTPDownloadEngine.materializeDirectories([[], [".."]], localRoot: tempRoot)
+        )
+    }
+
+    func testDirectoryPlanSkipsUnsafeRemoteNames() async throws {
+        let budget = SFTPDownloadEngine.TransferBudget(requestLimit: 8, handleLimit: 2)
+        let entries = [
+            SFTPDownloadEngine.DirectoryEntry(name: "safe.txt", kind: .file, size: 100),
+            SFTPDownloadEngine.DirectoryEntry(name: "../escape.txt", kind: .file, size: 100),
+            SFTPDownloadEngine.DirectoryEntry(name: "evil/nested.txt", kind: .file, size: 100),
+            SFTPDownloadEngine.DirectoryEntry(name: "null\0byte.txt", kind: .file, size: 100)
+        ]
+
+        let plan = try await SFTPDownloadEngine.makeDirectoryDownloadPlan(
+            remoteRoot: "/remote/test",
+            budget: budget,
+            configuration: .init()
+        ) { _ in entries }
+
+        XCTAssertEqual(plan.files.map(\.relativeComponents), [["safe.txt"]])
+    }
+
 }

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -730,6 +730,33 @@ final class SFTPBrowserTests: XCTestCase {
         XCTAssertEqual(browser.configuration.handleLimit, 4)
         XCTAssertEqual(browser.configuration.maxConcurrentFiles, 4)
     }
+
+    func testProgressAccumulatorKeepsKnownAndUnknownFileSizesSeparate() async {
+        let updates = SFTPLockedValue<[SFTPDownloadEngine.ProgressUpdate]>([])
+        let reporter = SFTPDownloadEngine.ProgressAccumulator(
+            totalBytes: nil,
+            unresolvedFileSizes: 1,
+            knownBytes: 100
+        ) { update in
+            updates.withValue { $0.append(update) }
+        }
+
+        await reporter.emitInitial()
+        // The known file is refreshed by FSTAT from 100 to 120 bytes.  It must not consume the
+        // unresolved slot belonging to the second, unknown-size file.
+        await reporter.observeFileSize(listedSize: 100, snapshotSize: 120)
+        await reporter.add(120)
+        await reporter.observeFileSize(listedSize: nil, snapshotSize: nil)
+        await reporter.add(80)
+        // The unknown file has no FSTAT size; its EOF-terminated copy resolves the denominator.
+        await reporter.observeFileSize(listedSize: nil, snapshotSize: 80)
+        await reporter.finish()
+
+        let finished = updates.snapshot().last { $0.isFinished }
+        XCTAssertEqual(finished?.totalBytes, 200)
+        XCTAssertEqual(finished?.completedBytes, 200)
+    }
+
     func testDirectoryMaterializationHandlesRootSentinelAndNestedDirectories() throws {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("MaterializeTest-\(UUID().uuidString)", isDirectory: true)

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -730,4 +730,61 @@ final class SFTPBrowserTests: XCTestCase {
         XCTAssertEqual(browser.configuration.handleLimit, 4)
         XCTAssertEqual(browser.configuration.maxConcurrentFiles, 4)
     }
+    func testDirectoryMaterializationHandlesRootSentinelAndNestedDirectories() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MaterializeTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        // Directories with root sentinel [] and nested subdirectories
+        let directories: [[String]] = [
+            [], // root sentinel for localRoot
+            ["empty"],
+            ["nested"],
+            ["nested", "child"]
+        ]
+
+        XCTAssertNoThrow(
+            try SFTPDownloadEngine.materializeDirectories(directories, localRoot: tempRoot),
+            "Root sentinel [] must be safely handled without throwing ValidationError.emptyComponent"
+        )
+
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(atPath: tempRoot.path))
+        XCTAssertTrue(fm.fileExists(atPath: tempRoot.appendingPathComponent("empty").path))
+        XCTAssertTrue(fm.fileExists(atPath: tempRoot.appendingPathComponent("nested").path))
+        XCTAssertTrue(fm.fileExists(atPath: tempRoot.appendingPathComponent("nested/child").path))
+    }
+
+    func testDirectoryMaterializationFromPlanWithRootSentinelSucceeds() async throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PlanMaterializeTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let budget = SFTPDownloadEngine.TransferBudget(requestLimit: 8, handleLimit: 2)
+        let entries = [
+            SFTPDownloadEngine.DirectoryEntry(name: "subfolder", kind: .directory, size: 0, sizeIsKnown: false),
+            SFTPDownloadEngine.DirectoryEntry(name: "file.txt", kind: .file, size: 10, sizeIsKnown: true)
+        ]
+
+        let plan = try await SFTPDownloadEngine.makeDirectoryDownloadPlan(
+            remoteRoot: "/remote/dir",
+            budget: budget,
+            configuration: .init()
+        ) { path in
+            if path == "/remote/dir" {
+                return entries
+            }
+            return []
+        }
+
+        // plan.directories[0] is [] (root sentinel)
+        XCTAssertEqual(plan.directories.first, [])
+        XCTAssertEqual(plan.directories.count, 2) // [] and ["subfolder"]
+
+        XCTAssertNoThrow(
+            try SFTPDownloadEngine.materializeDirectories(plan.directories, localRoot: tempRoot)
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempRoot.appendingPathComponent("subfolder").path))
+    }
+
 }

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -842,4 +842,36 @@ final class SFTPBrowserTests: XCTestCase {
         XCTAssertEqual(plan.files.map(\.relativeComponents), [["safe.txt"]])
     }
 
+    @MainActor
+    func testDragDownloadRejectsUnsafeTopLevelNameBeforeSFTPAccess() async {
+        let browser = SFTPBrowser {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let entry = SFTPBrowser.Entry(
+            name: "../escape.txt",
+            isDirectory: false,
+            isSymlink: false,
+            size: 1,
+            sizeIsKnown: true,
+            modified: nil
+        )
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("must-not-be-created-\(UUID().uuidString)")
+
+        do {
+            try await browser.downloadForDrag(
+                entry,
+                remoteDirectory: "/remote",
+                to: destination,
+                progress: Progress(totalUnitCount: 1)
+            )
+            XCTFail("unsafe top-level SFTP name must be rejected")
+        } catch let error as LocalPathComponentValidator.ValidationError {
+            XCTAssertEqual(error, .invalidCharacters(component: "../escape.txt"))
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
+    }
+
 }

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -1,62 +1,29 @@
 import XCTest
 @testable import Berth
 
+private final class SFTPLockedValue<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func withValue<Result>(_ body: (inout Value) -> Result) -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(&value)
+    }
+
+    func snapshot() -> Value {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
 @MainActor
 final class SFTPBrowserTests: XCTestCase {
-
-    func testDirectoryDownloadPlanRecursesAndSkipsSymlinks() async throws {
-        typealias Item = SFTPBrowser.DownloadTreeEntry
-        let tree: [String: [Item]] = [
-            "/srv/project": [
-                Item(name: "empty", kind: .directory, size: 0),
-                Item(name: "README.md", kind: .file, size: 12),
-                Item(name: "nested", kind: .directory, size: 0),
-                Item(name: "outside", kind: .symlink, size: 8),
-                Item(name: ".", kind: .directory, size: 0),
-            ],
-            "/srv/project/empty": [],
-            "/srv/project/nested": [
-                Item(name: "data.bin", kind: .file, size: 32),
-                Item(name: "deeper", kind: .directory, size: 0),
-            ],
-            "/srv/project/nested/deeper": [
-                Item(name: "zero", kind: .file, size: 0),
-            ],
-        ]
-        var listedPaths: [String] = []
-
-        let plan = try await SFTPBrowser.makeDirectoryDownloadPlan(remoteRoot: "/srv/project") { path in
-            listedPaths.append(path)
-            return tree[path] ?? []
-        }
-
-        XCTAssertEqual(listedPaths, [
-            "/srv/project",
-            "/srv/project/empty",
-            "/srv/project/nested",
-            "/srv/project/nested/deeper",
-        ])
-        XCTAssertEqual(plan.directories, [[], ["empty"], ["nested"], ["nested", "deeper"]])
-        XCTAssertEqual(plan.files, [
-            SFTPBrowser.DownloadTreeFile(
-                remotePath: "/srv/project/README.md",
-                relativeComponents: ["README.md"],
-                size: 12
-            ),
-            SFTPBrowser.DownloadTreeFile(
-                remotePath: "/srv/project/nested/data.bin",
-                relativeComponents: ["nested", "data.bin"],
-                size: 32
-            ),
-            SFTPBrowser.DownloadTreeFile(
-                remotePath: "/srv/project/nested/deeper/zero",
-                relativeComponents: ["nested", "deeper", "zero"],
-                size: 0
-            ),
-        ])
-        XCTAssertEqual(plan.totalBytes, 44)
-        XCTAssertEqual(plan.skippedSymlinks, 1)
-    }
 
     /// 递归删除:文件与符号链接先删(链接删自身),目录按最深优先,root 最后
     func testDirectoryDeletePlanOrdersDeepestFirst() async throws {
@@ -156,25 +123,560 @@ final class SFTPBrowserTests: XCTestCase {
     func testChunkCopyContinuesAfterShortRead() async throws {
         let payload = Data((0..<200_000).map { UInt8($0 % 251) })
         let serverPacketSize = 32 * 1024
-        var readOffsets: [UInt64] = []
-        var downloaded = Data()
+        let readOffsets = SFTPLockedValue<[UInt64]>([])
+        let downloaded = SFTPLockedValue<Data>(Data())
 
-        let copied = try await SFTPBrowser.copyDownloadChunks(
-            chunkSize: 256 * 1024,
+        let copied = try await SFTPDownloadEngine.copyUnknownSize(
+            chunkSize: UInt32(256 * 1024),
             read: { offset, requestedLength in
-                readOffsets.append(offset)
+                readOffsets.withValue { $0.append(offset) }
                 let start = Int(offset)
                 guard start < payload.count else { return Data() }
                 let count = min(serverPacketSize, Int(requestedLength), payload.count - start)
                 return payload.subdata(in: start..<(start + count))
             },
-            write: { downloaded.append($0) }
+            write: { data, _ in downloaded.withValue { $0.append(data) } }
         )
 
-        XCTAssertEqual(downloaded, payload)
+        XCTAssertEqual(downloaded.snapshot(), payload)
         XCTAssertEqual(copied, UInt64(payload.count))
-        XCTAssertEqual(readOffsets.first, 0)
-        XCTAssertEqual(readOffsets.last, UInt64(payload.count), "完整写入后还应再读一次空包确认 EOF")
-        XCTAssertGreaterThan(readOffsets.count, 2, "首个短包后不能提前结束")
+        let offsets = readOffsets.snapshot()
+        XCTAssertEqual(offsets.first, 0)
+        XCTAssertEqual(offsets.last, UInt64(payload.count), "完整写入后还应再读一次空包确认 EOF")
+        XCTAssertGreaterThan(offsets.count, 2, "首个短包后不能提前结束")
+    }
+
+    func testKnownSizePipelineWritesOutOfOrderResponsesAtTheirOffsets() async throws {
+        let payload = Data((0..<100).map { UInt8($0) })
+        let writes = SFTPLockedValue<[UInt64: Data]>([:])
+
+        let copied = try await SFTPDownloadEngine.copyKnownSize(
+            expectedSize: UInt64(payload.count),
+            chunkSize: 25,
+            initialPipelineDepth: 4,
+            maxPipelineDepth: 4,
+            read: { offset, length in
+                // Deliberately make higher offsets complete first.
+                try await Task.sleep(for: .milliseconds(5 * Int((100 - offset) / 25)))
+                let start = Int(offset)
+                let count = min(Int(length), payload.count - start)
+                return payload.subdata(in: start..<(start + count))
+            },
+            write: { data, offset in writes.withValue { $0[offset] = data } }
+        )
+
+        XCTAssertEqual(copied, 100)
+        let written = writes.snapshot()
+        XCTAssertEqual(written.keys.sorted(), [0, 25, 50, 75])
+        XCTAssertEqual(Data(written.sorted { $0.key < $1.key }.flatMap(\.value)), payload)
+    }
+
+    func testKnownSizePipelineLazilySchedulesHugeFile() async throws {
+        actor Probe {
+            var calls = 0
+            func record() { calls += 1 }
+            var count: Int { calls }
+        }
+        let probe = Probe()
+
+        do {
+            _ = try await SFTPDownloadEngine.copyKnownSize(
+                expectedSize: UInt64.max,
+                chunkSize: 64,
+                initialPipelineDepth: 2,
+                maxPipelineDepth: 2,
+                read: { _, length in
+                    await probe.record()
+                    return Data(repeating: 0, count: Int(length) + 1)
+                },
+                write: { _, _ in }
+            )
+            XCTFail("expected invalid read length")
+        } catch let error as SFTPDownloadEngine.Error {
+            XCTAssertEqual(error, .invalidReadLength(requested: 64, received: 65))
+        }
+
+        // A pre-generated range array would attempt to create UInt64.max / 64 entries.  The
+        // lazy scheduler dispatches only the configured initial window before the first error.
+        let calls = await probe.count
+        XCTAssertLessThanOrEqual(calls, 2)
+    }
+
+    func testKnownSizePipelineRefillsShortReadsWithoutAnExtraEOFRead() async throws {
+        let payload = Data((0..<53).map { UInt8($0 % 251) })
+        let offsets = SFTPLockedValue<[UInt64]>([])
+        let requestedLengths = SFTPLockedValue<[UInt32]>([])
+        let writes = SFTPLockedValue<[UInt64: Data]>([:])
+
+        let copied = try await SFTPDownloadEngine.copyKnownSize(
+            expectedSize: UInt64(payload.count),
+            chunkSize: 32,
+            initialPipelineDepth: 2,
+            maxPipelineDepth: 2,
+            read: { offset, requestedLength in
+                offsets.withValue { $0.append(offset) }
+                requestedLengths.withValue { $0.append(requestedLength) }
+                let start = Int(offset)
+                guard start < payload.count else { return Data() }
+                let count = min(7, Int(requestedLength), payload.count - start)
+                return payload.subdata(in: start..<(start + count))
+            },
+            write: { data, offset in writes.withValue { $0[offset] = data } }
+        )
+
+        XCTAssertEqual(copied, UInt64(payload.count))
+        let written = writes.snapshot()
+        XCTAssertEqual(written.values.reduce(0) { $0 + $1.count }, payload.count)
+        XCTAssertEqual(Data(written.sorted { $0.key < $1.key }.flatMap(\.value)), payload)
+        let requestedOffsets = offsets.snapshot()
+        XCTAssertFalse(requestedOffsets.contains(UInt64(payload.count)), "已知大小不应额外发送 EOF READ")
+        XCTAssertGreaterThan(requestedOffsets.count, 2)
+        XCTAssertTrue(requestedLengths.snapshot().contains(8), "短读后后续 READ 应降低到自适应 chunk")
+    }
+
+    func testKnownSizePipelineReportsEarlyEOF() async throws {
+        do {
+            _ = try await SFTPDownloadEngine.copyKnownSize(
+                expectedSize: 40,
+                chunkSize: 16,
+                initialPipelineDepth: 1,
+                maxPipelineDepth: 1,
+                read: { offset, length in
+                    guard offset < 20 else { return Data() }
+                    return Data(repeating: 0xA5, count: min(Int(length), 10))
+                },
+                write: { _, _ in }
+            )
+            XCTFail("expected early EOF")
+        } catch let error as SFTPDownloadEngine.Error {
+            guard case let .earlyEOF(offset, expectedSize) = error else {
+                return XCTFail("unexpected error: \(error)")
+            }
+            XCTAssertEqual(expectedSize, 40)
+            XCTAssertGreaterThanOrEqual(offset, 20)
+            XCTAssertLessThan(offset, 40)
+        }
+    }
+
+    func testGlobalRequestBudgetLimitsConcurrentPipelines() async throws {
+        actor Probe {
+            var active = 0
+            var peak = 0
+
+            func enter() {
+                active += 1
+                peak = max(peak, active)
+            }
+
+            func leave() { active -= 1 }
+            var maximum: Int { peak }
+        }
+
+        let budget = SFTPDownloadEngine.TransferBudget(requestLimit: 3, handleLimit: 8)
+        let probe = Probe()
+        let payload = Data(repeating: 0x4D, count: 64)
+
+        try await withThrowingTaskGroup(of: UInt64.self) { group in
+            for _ in 0..<8 {
+                group.addTask {
+                    try await SFTPDownloadEngine.copyKnownSize(
+                        expectedSize: UInt64(payload.count),
+                        chunkSize: 16,
+                        initialPipelineDepth: 4,
+                        maxPipelineDepth: 4,
+                        budget: budget,
+                        read: { offset, length in
+                            await probe.enter()
+                            try await Task.sleep(for: .milliseconds(2))
+                            await probe.leave()
+                            return payload.subdata(in: Int(offset)..<Int(offset) + Int(length))
+                        },
+                        write: { _, _ in }
+                    )
+                }
+            }
+            while let _ = try await group.next() {}
+        }
+
+        let requestPeak = await probe.maximum
+        let budgetRequestPeak = await budget.peakRequestCount
+        let requestsRemaining = await budget.currentRequestCount
+        XCTAssertLessThanOrEqual(requestPeak, 3)
+        XCTAssertLessThanOrEqual(budgetRequestPeak, 3)
+        XCTAssertEqual(requestsRemaining, 0)
+    }
+
+    func testDirectoryScanUsesBoundedConcurrentListings() async throws {
+        actor Probe {
+            var active = 0
+            var peak = 0
+            func enter() { active += 1; peak = max(peak, active) }
+            func leave() { active -= 1 }
+            var maximum: Int { peak }
+        }
+
+        let probe = Probe()
+        let budget = SFTPDownloadEngine.TransferBudget(requestLimit: 16, handleLimit: 2)
+        let tree: [String: [SFTPDownloadEngine.DirectoryEntry]] = [
+            "/root": (0..<6).map {
+                .init(name: "dir\($0)", kind: .directory)
+            },
+        ]
+        var mutableTree = tree
+        for index in 0..<6 {
+            mutableTree["/root/dir\(index)"] = [
+                .init(name: "file.bin", kind: .file, size: 3),
+            ]
+        }
+
+        let directoryTree = mutableTree
+        let plan = try await SFTPDownloadEngine.makeDirectoryDownloadPlan(
+            remoteRoot: "/root",
+            budget: budget,
+            configuration: .init(maxConcurrentDirectories: 2)
+        ) { path in
+            await probe.enter()
+            try await Task.sleep(for: .milliseconds(2))
+            let result = directoryTree[path] ?? []
+            await probe.leave()
+            return result
+        }
+
+        XCTAssertEqual(plan.files.count, 6)
+        let listingPeak = await probe.maximum
+        let budgetHandlePeak = await budget.peakHandleCount
+        let handlesRemaining = await budget.currentHandleCount
+        XCTAssertLessThanOrEqual(listingPeak, 2)
+        XCTAssertLessThanOrEqual(budgetHandlePeak, 2)
+        XCTAssertEqual(handlesRemaining, 0)
+    }
+
+    func testRequestBudgetFIFOHandlesCancellationBeforeAndAfterGrant() async throws {
+        actor Recorder {
+            var labels: [String] = []
+            func append(_ label: String) { labels.append(label) }
+            var snapshot: [String] { labels }
+        }
+
+        let budget = SFTPDownloadEngine.TransferBudget(requestLimit: 1, handleLimit: 1)
+        let recorder = Recorder()
+        try await budget.acquireRequest() // Keep the first permit occupied while waiters queue.
+
+        let first = Task {
+            try await budget.acquireRequest()
+            await recorder.append("first")
+            await budget.releaseRequest()
+        }
+        let second = Task {
+            try await budget.acquireRequest()
+            await recorder.append("second")
+            await budget.releaseRequest()
+        }
+
+        var queued = false
+        for _ in 0..<1_000 {
+            if await budget.requestWaiterCount == 2 {
+                queued = true
+                break
+            }
+            await Task.yield()
+        }
+        XCTAssertTrue(queued, "both FIFO waiters must be observable before releasing the holder")
+        first.cancel()
+
+        var firstRemoved = false
+        for _ in 0..<1_000 {
+            if await budget.requestWaiterCount == 1 {
+                firstRemoved = true
+                break
+            }
+            await Task.yield()
+        }
+        XCTAssertTrue(firstRemoved, "cancelling a queued waiter must remove it before grant")
+        await budget.releaseRequest()
+
+        do {
+            _ = try await first.value
+            XCTFail("cancelled FIFO waiter should not acquire a permit")
+        } catch is CancellationError {
+            // expected
+        }
+        try await second.value
+        let labelsAfterQueuedCancel = await recorder.snapshot
+        XCTAssertEqual(labelsAfterQueuedCancel, ["second"], "FIFO must skip the cancelled waiter")
+        let requestCountAfterQueuedCancel = await budget.currentRequestCount
+        XCTAssertEqual(requestCountAfterQueuedCancel, 0)
+
+        // Exercise cancellation after the semaphore has granted the waiter.  The gate stops the
+        // resumed waiter exactly before its cancellation check/confirmation, so this does not
+        // depend on a scheduler window.
+        let grantGate = SFTPDownloadEngine.GrantConfirmationGate()
+        await budget.installRequestGrantConfirmationGate(grantGate)
+        try await budget.acquireRequest()
+        let granted = Task {
+            try await budget.acquireRequest()
+            await recorder.append("granted")
+            await budget.releaseRequest()
+        }
+
+        var grantedQueued = false
+        for _ in 0..<1_000 {
+            if await budget.requestWaiterCount == 1 {
+                grantedQueued = true
+                break
+            }
+            await Task.yield()
+        }
+        XCTAssertTrue(grantedQueued, "the cancellation candidate must be queued before releasing the holder")
+        await budget.releaseRequest()
+
+        await grantGate.waitUntilGrant()
+        let labelsBeforeConfirmation = await recorder.snapshot
+        XCTAssertFalse(labelsBeforeConfirmation.contains("granted"), "grant must pause before confirmation")
+
+        // Cancel while the granted waiter is stopped before confirmation, then open the barrier
+        // so its cancellation path can release the granted permit and unwind.
+        granted.cancel()
+
+        await grantGate.release()
+        do {
+            _ = try await granted.value
+            XCTFail("cancelled granted waiter should throw")
+        } catch is CancellationError {
+            // expected
+        }
+
+        let requestCountAfterGrantedCancel = await budget.currentRequestCount
+        let waiterCountAfterGrantedCancel = await budget.requestWaiterCount
+        XCTAssertEqual(requestCountAfterGrantedCancel, 0)
+        XCTAssertEqual(waiterCountAfterGrantedCancel, 0)
+
+        // Successor A now acquires the recovered permit and holds it while successor B queues.
+        // Keeping A's permit live makes any extra release observable by the count/ordering
+        // assertions below rather than relying on `release()`'s defensive floor at zero.
+        actor PermitHoldGate {
+            private var didEnter = false
+            private var released = false
+            private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+            private var releaseWaiter: CheckedContinuation<Void, Never>?
+
+            func waitUntilEntered() async {
+                if didEnter { return }
+                await withCheckedContinuation { continuation in
+                    if didEnter {
+                        continuation.resume()
+                    } else {
+                        entryWaiters.append(continuation)
+                    }
+                }
+            }
+
+            func enterAndHold() async {
+                didEnter = true
+                let waiters = entryWaiters
+                entryWaiters.removeAll(keepingCapacity: false)
+                for waiter in waiters {
+                    waiter.resume()
+                }
+                if released { return }
+                await withCheckedContinuation { continuation in
+                    if released {
+                        continuation.resume()
+                    } else {
+                        releaseWaiter = continuation
+                    }
+                }
+            }
+
+            func release() {
+                released = true
+                releaseWaiter?.resume()
+                releaseWaiter = nil
+            }
+        }
+
+        let successorAHold = PermitHoldGate()
+        let successorA = Task {
+            try await budget.acquireRequest()
+            await recorder.append("A")
+            await successorAHold.enterAndHold()
+            await budget.releaseRequest()
+        }
+        await successorAHold.waitUntilEntered()
+
+        let requestCountWhileSuccessorAHolds = await budget.currentRequestCount
+        XCTAssertEqual(requestCountWhileSuccessorAHolds, 1)
+
+        let successorB = Task {
+            try await budget.acquireRequest()
+            await recorder.append("B")
+            await budget.releaseRequest()
+        }
+        var successorBQueued = false
+        for _ in 0..<1_000 {
+            if await budget.requestWaiterCount == 1 {
+                successorBQueued = true
+                break
+            }
+            await Task.yield()
+        }
+        XCTAssertTrue(successorBQueued, "successor B must wait behind successor A")
+
+        await successorAHold.release()
+        try await successorA.value
+        try await successorB.value
+
+        let labelsAfterGrantedCancel = await recorder.snapshot
+        XCTAssertEqual(labelsAfterGrantedCancel, ["second", "A", "B"], "FIFO must advance through the recovered permit")
+        let requestPeakAfterGrantedCancel = await budget.peakRequestCount
+        let finalRequestCount = await budget.currentRequestCount
+        let finalWaiterCount = await budget.requestWaiterCount
+        XCTAssertEqual(finalRequestCount, 0)
+        XCTAssertEqual(finalWaiterCount, 0)
+        XCTAssertEqual(requestPeakAfterGrantedCancel, 1)
+    }
+
+    func testPipelineCancellationDoesNotDispatchAfterTaskGroupDrains() async throws {
+        actor Probe {
+            var offsets: [UInt64] = []
+            func record(_ offset: UInt64) { offsets.append(offset) }
+            var count: Int { offsets.count }
+        }
+        let probe = Probe()
+        let task = Task {
+            try await SFTPDownloadEngine.copyKnownSize(
+                expectedSize: 1024,
+                chunkSize: 64,
+                initialPipelineDepth: 4,
+                maxPipelineDepth: 4,
+                read: { offset, length in
+                    await probe.record(offset)
+                    try await Task.sleep(for: .milliseconds(100))
+                    try Task.checkCancellation()
+                    return Data(repeating: 0, count: Int(length))
+                },
+                write: { _, _ in }
+            )
+        }
+        try await Task.sleep(for: .milliseconds(5))
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("expected cancellation")
+        } catch is CancellationError {
+            // expected
+        }
+        let dispatched = await probe.count
+        XCTAssertLessThanOrEqual(dispatched, 4)
+    }
+
+    func testOpenedFileCancellationDrainsReadsBeforeCloseAndReleasesBudgets() async throws {
+        struct FakeHandle: Sendable {
+            let id = 1
+        }
+        actor Probe {
+            struct ReadWaiter {
+                let length: UInt32
+                let continuation: CheckedContinuation<Data, Never>
+            }
+
+            var events: [String] = []
+            var waiters: [ReadWaiter] = []
+
+            func open() -> FakeHandle {
+                events.append("open")
+                return FakeHandle()
+            }
+
+            func snapshot() -> UInt64? {
+                events.append("snapshot")
+                return 64
+            }
+
+            func read(offset: UInt64, length: UInt32) async -> Data {
+                events.append("read-start-\(offset)")
+                return await withCheckedContinuation { continuation in
+                    waiters.append(ReadWaiter(length: length, continuation: continuation))
+                }
+            }
+
+            func releaseReads() {
+                let pending = waiters
+                waiters.removeAll()
+                for waiter in pending {
+                    events.append("read-return")
+                    waiter.continuation.resume(returning: Data(repeating: 0, count: Int(waiter.length)))
+                }
+            }
+
+            func close() {
+                events.append("close")
+            }
+
+            var readStartCount: Int { events.filter { $0.hasPrefix("read-start-") }.count }
+            var closeCount: Int { events.filter { $0 == "close" }.count }
+            var eventList: [String] { events }
+        }
+
+        let probe = Probe()
+        let budget = SFTPDownloadEngine.TransferBudget(requestLimit: 4, handleLimit: 1)
+        let localURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("berth-download-cancel-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: localURL) }
+
+        let transfer = Task {
+            try await SFTPDownloadEngine.downloadOpenedFileLifecycle(
+                expectedSize: 64,
+                localURL: localURL,
+                chunkSize: 32,
+                configuration: .init(initialPipelineDepth: 2, maxPipelineDepth: 2),
+                budget: budget,
+                open: { await probe.open() },
+                snapshot: { _ in await probe.snapshot() },
+                read: { _, offset, length in await probe.read(offset: offset, length: length) },
+                close: { _ in await probe.close() }
+            )
+        }
+
+        var readsStarted = false
+        for _ in 0..<1_000 {
+            if await probe.readStartCount == 2 {
+                readsStarted = true
+                break
+            }
+            await Task.yield()
+        }
+        XCTAssertTrue(readsStarted, "the fake must have two in-flight READs before cancellation")
+        transfer.cancel()
+        await Task.yield()
+        let closeCountBeforeDrain = await probe.closeCount
+        let readCountBeforeDrain = await probe.readStartCount
+        XCTAssertEqual(closeCountBeforeDrain, 0, "CLOSE must wait for the ignored-cancellation READs")
+        XCTAssertEqual(readCountBeforeDrain, 2, "cancellation must stop new READ dispatch")
+
+        await probe.releaseReads()
+        do {
+            _ = try await transfer.value
+            XCTFail("cancelled transfer should throw")
+        } catch is CancellationError {
+            // expected
+        }
+
+        let events = await probe.eventList
+        let lastReadReturn = events.lastIndex(of: "read-return")
+        let closeIndex = events.lastIndex(of: "close")
+        XCTAssertNotNil(lastReadReturn)
+        XCTAssertNotNil(closeIndex)
+        if let lastReadReturn, let closeIndex {
+            XCTAssertLessThan(lastReadReturn, closeIndex, "remote CLOSE must follow drained READs")
+        }
+        let finalReadCount = await probe.readStartCount
+        let finalCloseCount = await probe.closeCount
+        let finalRequestCount = await budget.currentRequestCount
+        let finalHandleCount = await budget.currentHandleCount
+        XCTAssertEqual(finalReadCount, 2)
+        XCTAssertEqual(finalCloseCount, 1)
+        XCTAssertEqual(finalRequestCount, 0)
+        XCTAssertEqual(finalHandleCount, 0)
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -100,6 +100,7 @@ targets:
       - path: Berth/Core/SSH/ProxyConnector.swift
       - path: Berth/Core/SSH/SOCKS5.swift
       - path: Berth/Core/SSH/SFTPBrowser.swift
+      - path: Berth/Core/SSH/SFTPDownloadEngine.swift
       - path: Berth/Core/SSH/ServerInfo.swift
       - path: Berth/Core/Services/KeyStore.swift
       - path: Berth/Core/Services/HostReachability.swift

--- a/project.yml
+++ b/project.yml
@@ -91,6 +91,7 @@ targets:
       - path: Berth/Core/SSH/SSHErrorMapper.swift
       - path: Berth/Core/SSH/KeyboardInteractiveAuth.swift
       - path: Berth/Core/SSH/KnownHostsStore.swift
+      - path: Berth/Core/SSH/LocalPathComponentValidator.swift
       - path: Berth/Core/SSH/HostKeyValidation.swift
       - path: Berth/Core/SSH/OpenSSHFormat.swift
       - path: Berth/Core/SSH/PrivateKeyFormat.swift

--- a/vendor/Citadel/Sources/Citadel/SFTP/Client/SFTPClient.swift
+++ b/vendor/Citadel/Sources/Citadel/SFTP/Client/SFTPClient.swift
@@ -155,6 +155,8 @@ public final class SFTPClient: Sendable {
         var oldPath: String
 
         repeat {
+            // [Berth patch] cancellation is checked before every request in the realpath walk.
+            try Task.checkCancellation()
             oldPath = path
             guard case .name(let realpath) = try await sendRequest(.realpath(.init(requestId: self.allocateRequestId(), path: path))) else {
                 self.logger.warning("SFTP server returned bad response to open file request, this is a protocol error")
@@ -164,24 +166,22 @@ public final class SFTPClient: Sendable {
             path = realpath.path
         } while path != oldPath
         
+        // [Berth patch] do not create a directory handle after cancellation was requested.
+        try Task.checkCancellation()
         guard case .handle(let handle) = try await sendRequest(.opendir(.init(requestId: self.allocateRequestId(), handle: path))) else {
             self.logger.warning("SFTP server returned bad response to open file request, this is a protocol error")
             throw SFTPError.invalidResponse
         }
-        
-        var names = [SFTPMessage.Name]()
-        var response = try await sendRequest(
-            .readdir(
-                .init(
-                    requestId: self.allocateRequestId(),
-                    handle: handle.handle
-                )
-            )
-        )
-        
-        while case .name(let name) = response {
-            names.append(name)
-            response = try await sendRequest(
+
+        // OPENDIR consumes one server handle just like OPEN.  Close it on both success and every
+        // failure path (including cancellation), otherwise recursive scans leak one handle per
+        // directory and eventually hit the server's max-open-handles limit. [Berth patch]
+        var didClose = false
+        do {
+            var names = [SFTPMessage.Name]()
+            // [Berth patch] cancellation before the initial READDIR is caught below and closes.
+            try Task.checkCancellation()
+            var response = try await sendRequest(
                 .readdir(
                     .init(
                         requestId: self.allocateRequestId(),
@@ -189,9 +189,52 @@ public final class SFTPClient: Sendable {
                     )
                 )
             )
+
+            while case .name(let name) = response {
+                names.append(name)
+                // [Berth patch] an in-flight READDIR is allowed to finish, but no next request is
+                // sent after cancellation has become observable.
+                try Task.checkCancellation()
+                response = try await sendRequest(
+                    .readdir(
+                        .init(
+                            requestId: self.allocateRequestId(),
+                            handle: handle.handle
+                        )
+                    )
+                )
+            }
+
+            try await closeDirectoryHandle(handle.handle)
+            didClose = true
+            return names
+        } catch {
+            // [Berth patch] close is deliberately not cancellation-gated; sendRequest itself has
+            // no cancellation check, so the already-open handle is drained and closed here.
+            if !didClose {
+                try? await closeDirectoryHandleIgnoringCancellation(handle.handle)
+            }
+            throw error
         }
-        
-        return names
+    }
+
+    // [Berth patch] cleanup has no Task.checkCancellation and therefore still sends CLOSE after
+    // a caller's READDIR task is cancelled.  The caller awaits this function before returning.
+    private func closeDirectoryHandleIgnoringCancellation(_ handle: ByteBuffer) async throws {
+        try await closeDirectoryHandle(handle)
+    }
+
+    private func closeDirectoryHandle(_ handle: ByteBuffer) async throws {
+        let response = try await sendRequest(.closeFile(.init(
+            requestId: allocateRequestId(),
+            handle: handle
+        )))
+        guard case .status(let status) = response else {
+            throw SFTPError.invalidResponse
+        }
+        guard status.errorCode == .ok else {
+            throw SFTPError.errorStatus(status)
+        }
     }
     
     /// Get the attributes of a file on the SFTP server.
@@ -268,7 +311,9 @@ public final class SFTPClient: Sendable {
         }
             
         self.logger.debug("SFTP opened file \(filePath), file handle \(handle.handle.sftpHandleDebugDescription)")
-        return SFTPFile(client: self, path: filePath, handle: handle.handle)
+        // [Berth patch] SFTPFile only needs the server handle; path STAT was removed in favor
+        // of handle-scoped FSTAT for a consistent download snapshot.
+        return SFTPFile(client: self, handle: handle.handle)
     }
     
     /// Open and automatically close a file with the given closure.

--- a/vendor/Citadel/Sources/Citadel/SFTP/Client/SFTPFile.swift
+++ b/vendor/Citadel/Sources/Citadel/SFTP/Client/SFTPFile.swift
@@ -1,24 +1,27 @@
 import NIO
+import NIOConcurrencyHelpers // [Berth patch] protects SFTPFile's cross-task active state.
 import Logging
 
 /// A "handle" for accessing a file that has been successfully opened on an SFTP server. File handles support
 /// reading (if opened with read access) and writing/appending (if opened with write/append access).
-public final class SFTPFile {
+public final class SFTPFile: @unchecked Sendable { // [Berth patch] READ pipeline shares one handle.
     /// A typealias to clarify when a buffer is being used as a file handle.
     ///
     /// This should probably be a `struct` wrapping a buffer for stronger type safety.
     public typealias SFTPFileHandle = ByteBuffer
     
     /// Indicates whether the file's handle was still valid at the time the getter was called.
-    public private(set) var isActive: Bool
+    private let activeState: NIOLockedValueBox<Bool> // [Berth patch] serialize close/read lifecycle.
+
+    public var isActive: Bool {
+        activeState.withLockedValue { $0 }
+    }
     
     /// The raw buffer whose contents are were contained in the `.handle()` result from the SFTP server.
     /// Used for performing operations on the open file.
     ///
     /// - Note: Make this `private` when concurrency isn't in a separate file anymore.
     internal let handle: SFTPFileHandle
-    
-    internal let path: String
     
     /// The `SFTPClient` this handle belongs to.
     ///
@@ -29,11 +32,10 @@ public final class SFTPFile {
     /// having taken ownership of the handle; nothing else should continue to use the handle.
     ///
     /// Do not create instances of `SFTPFile` yourself; use `SFTPClient.openFile()`.
-    internal init(client: SFTPClient, path: String, handle: SFTPFileHandle) {
-        self.isActive = true
+    internal init(client: SFTPClient, handle: SFTPFileHandle) {
+        self.activeState = NIOLockedValueBox(true)
         self.handle = handle
         self.client = client
-        self.path = path
     }
     
     /// A `Logger` for the file. Uses the logger of the client that opened the file.
@@ -45,7 +47,7 @@ public final class SFTPFile {
         }
     }
     
-    /// Read the attributes of the file. This is equivalent to the `stat()` system call.
+    /// Read the attributes of the file handle. This is equivalent to the `fstat()` system call.
     ///
     /// - Returns: File attributes including size, permissions, etc
     /// - Throws: SFTPError if the file handle is invalid or request fails
@@ -62,9 +64,10 @@ public final class SFTPFile {
     public func readAttributes() async throws -> SFTPFileAttributes {
         guard self.isActive else { throw SFTPError.fileHandleInvalid }
         
-        guard case .attributes(let attributes) = try await self.client.sendRequest(.stat(.init(
+        // [Berth patch] FSTAT must address this open handle; STAT(path) is a stale/racy snapshot.
+        guard case .attributes(let attributes) = try await self.client.sendRequest(.fstat(.init(
             requestId: self.client.allocateRequestId(),
-            path: path
+            handle: self.handle
         ))) else {
             self.logger.warning("SFTP server returned bad response to read file request, this is a protocol error")
             throw SFTPError.invalidResponse
@@ -261,7 +264,12 @@ public final class SFTPFile {
         
         self.logger.debug("SFTP closing and invalidating file \(self.handle.sftpHandleDebugDescription)")
         
-        self.isActive = false
+        // [Berth patch] atomically claim the close so concurrent cleanup cannot send duplicate CLOSE.
+        guard activeState.withLockedValue({ active -> Bool in
+            guard active else { return false }
+            active = false
+            return true
+        }) else { return }
         let result = try await self.client.sendRequest(.closeFile(.init(requestId: self.client.allocateRequestId(), handle: self.handle)))
         
         guard case .status(let status) = result else {

--- a/vendor/PATCHES.md
+++ b/vendor/PATCHES.md
@@ -155,3 +155,21 @@ Citadel 自带 `DiffieHellmanGroup14Sha1/Sha256` 与 `AES128CTR` 实现(Berth �
 ## 升级 Citadel/nio-ssh 时
 本地 vendor 已脱离 SPM 版本管理。若要升级,需重新 vendor 对应版本并重放上述 `[Berth patch]`
 改动(`grep -rn "\[Berth patch\]" vendor/` 可列出全部补丁点)。
+
+## 补丁: SFTP listDirectory 关闭 OPENDIR handle
+
+`SFTPClient.listDirectory(atPath:)` 原先在读取完目录后直接返回,没有发送
+`SSH_FXP_CLOSE`。递归下载/删除大量目录时会因此泄漏远端目录 handle,最终触发服务器的
+`max-open-handles` 限制。现已在成功、READDIR 失败和取消路径统一结构化等待 CLOSE；标记
+`[Berth patch]`，位置为 `Sources/Citadel/SFTP/Client/SFTPClient.swift`。
+
+## 补丁:SFTPFile 使用 FSTAT 并允许受控并发读取
+
+`SFTPFile.readAttributes()` 原先按路径发送 `STAT`，打开文件后若路径被替换会读到另一份
+文件的大小。现改为按已打开 handle 发送 `FSTAT`，供下载器在 READ 调度前取得该时点的
+size snapshot；移除不再使用的 path 字段，避免误导调用方继续走路径属性；同时以
+`NIOLockedValueBox` 保护 `isActive`，并标记 `SFTPFile` 为 `@unchecked Sendable`，使同一
+handle 的并发 READ 与结构化 CLOSE 具备明确的生命周期。关闭操作先在锁内原子地 claim
+handle，再发送一次 CLOSE，避免并发清理重复发送。上述每个 vendor 修改点均在源码带有
+`[Berth patch]` 标记，位置为 `Sources/Citadel/SFTP/Client/SFTPFile.swift` 及
+`Sources/Citadel/SFTP/Client/SFTPClient.swift` 的构造调用。


### PR DESCRIPTION
## 变更概述

将 SFTP 目录下载从逐文件、逐块串行读取改为有界 pipeline，重点改善包含大量目录、文件和大体积 checkpoint 文件的下载性能，同时限制对服务器和本机资源的占用。

- 单文件维持多个并发 `READ` 请求，并按远端 offset 写入正确位置。
- 多文件和目录扫描采用有界并发，不为每个文件创建无限制 pipeline。
- 全局共享 request/handle budget，所有顶层下载共同遵守服务器请求数和打开句柄上限。
- 目录扫描先建立下载计划，已知大小时提供准确总进度；未知大小按 EOF 实际字节数补齐。
- 取消下载时停止继续派发请求，等待在途读取收敛后关闭句柄并释放 budget。
- 跳过远端符号链接，验证顶层名称及每一级本地路径组件，防止路径穿越或写出目标根目录。

## 默认并发配置

- 初始单文件 pipeline 深度：2
- 单文件 pipeline 深度上限：8
- 并发文件数：8
- 并发目录扫描数：4
- 全局未完成请求上限：64
- 全局打开句柄上限：16
- SFTP v3 回退块大小：32 KiB

这些值由同一个 `SFTPTransferConfiguration` 归一化并传给下载器和全局 budget，避免 UI 层与下载引擎的限制不一致；也可通过现有环境变量做本地 A/B 调优或临时降载。

## Citadel vendor 补丁

- `listDirectory(atPath:)` 在成功、失败和取消路径都结构化关闭 `OPENDIR` handle，避免递归扫描最终耗尽服务器的 `max-open-handles`。
- 文件属性查询由路径 `STAT` 改为已打开 handle 的 `FSTAT`，防止打开后路径被替换导致大小快照不一致。
- 保护 `SFTPFile` 的跨任务 active/close 状态，确保并发 READ 完成后只发送一次 CLOSE。
- 所有修改均在源码以 `[Berth patch]` 标记，并记录在 `vendor/PATCHES.md`，便于升级依赖时重放。

## 安全与边界

- 拒绝空名称、`.`、`..`、绝对路径、NUL、`/` 及会逃逸目标根目录的路径组件。
- 目录计划中的根哨兵 `[]` 不会被当作空文件名创建。
- 远端符号链接暂不跟随，避免循环和目标根目录外写入。
- 同名目标的原子替换、目录冲突策略以及 Finder 拖拽临时文件生命周期会在后续独立 PR 中提交，本 PR 不夹带这些策略。

## 验证

- SFTP pipeline、目录扫描、全局 budget、公平排队、取消收敛、未知大小进度、根哨兵和路径逃逸回归测试均已通过。
- 本分支包含 21 个 `SFTPBrowserTests` 和 5 个 `LocalPathComponentValidatorTests`。
- 已检查 `git diff --check`，没有空白或补丁格式问题。
- 本 PR 未验证 iOS；目标为 macOS SFTP 下载路径。
- 经过实测：拖动拥有巨量小文件的文件夹（约 600 个目录、13,800 个文件，一共 2G）进行下载的速度大概为原来的三倍左右，显著超过 Tabby 的下载速度，但是仍然不及 Windterm 的下载速度。

## PR 顺序

这是拆分系列的第 3 个 PR。建议按 #23 → #24 → 本 PR 的顺序审查和合并。

为避免避免 GitHub diff 重复包含 pipeline 代码，「Finder 拖拽生命周期」以及「下载目标原子提交」将分别等待本 PR 和其前置 PR 合并后再提交。
