### PR TITLE
功能：完善 SFTP 拖拽下载的取消与临时文件生命周期

### DIFF
--- a/Berth/App/BerthApp.swift
+++ b/Berth/App/BerthApp.swift
@@ -6,6 +6,7 @@ import SwiftUI
 final class BerthAppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         MenuBarItemController.shared.start()
+        Task { _ = try? await SFTPDragStagingStore.shared.sweepStale() }
     }
 }
 

--- a/Berth/Core/SSH/LocalPathComponentValidator.swift
+++ b/Berth/Core/SSH/LocalPathComponentValidator.swift
@@ -22,6 +22,14 @@ enum LocalPathComponentValidator {
         }
     }
 
+    /// 验证单个路径分量 (例如 entry.name)。
+    /// 拒绝:
+    /// - 空字符串
+    /// - "." 或 ".."
+    /// - 包含 "/" (路径分隔符)
+    /// - 包含 NUL ("\0")
+    /// - 包含 ASCII 控制字符
+    /// 提示: 在 Linux / Unix 与 macOS 本地文件系统中, "\" (反斜杠) 为合法文件名字符而非路径分隔符, 予以保留。
     static func validateComponent(_ component: String) throws {
         guard !component.isEmpty else {
             throw ValidationError.emptyComponent

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -289,6 +289,7 @@ final class SFTPBrowser {
     private static let uploadChunkSize = 256 * 1024
 
     private var downloadTasks: [UUID: Task<SFTPDownloadEngine.SFTPDownloadResult, Error>] = [:]
+    private var cancellationHandlers: [UUID: @Sendable () -> Void] = [:]
 
     typealias DownloadExecutor = @Sendable (
         _ entry: Entry,
@@ -351,7 +352,11 @@ final class SFTPBrowser {
         guard let index = transfers.firstIndex(where: { $0.id == id }) else { return }
         guard transfers[index].canCancel, !transfers[index].isCancelling else { return }
         transfers[index].isCancelling = true
-        downloadTasks[id]?.cancel()
+        if let handler = cancellationHandlers[id] {
+            handler()
+        } else {
+            downloadTasks[id]?.cancel()
+        }
     }
 
     private func setTransfer(_ id: UUID, label: String) {
@@ -425,10 +430,6 @@ final class SFTPBrowser {
             progress: !entry.isDirectory && entry.size > 0 ? 0 : nil,
             canCancel: true
         )
-        defer {
-            downloadTasks.removeValue(forKey: transferID)
-            endTransfer(transferID)
-        }
         let sink = SFTPDownloadProgressSink(progress: externalProgress) { [weak self] update in
             guard let self else { return }
             if let totalBytes = update.totalBytes, totalBytes > 0 {
@@ -469,6 +470,21 @@ final class SFTPBrowser {
             )
         }
         downloadTasks[transferID] = transferTask
+        if let externalProgress {
+            cancellationHandlers[transferID] = { [weak externalProgress] in
+                externalProgress?.cancel()
+                transferTask.cancel()
+            }
+        } else {
+            cancellationHandlers[transferID] = {
+                transferTask.cancel()
+            }
+        }
+        defer {
+            cancellationHandlers.removeValue(forKey: transferID)
+            downloadTasks.removeValue(forKey: transferID)
+            endTransfer(transferID)
+        }
 
         if Task.isCancelled {
             transferTask.cancel()
@@ -913,6 +929,8 @@ final class SFTPBrowser {
         editTasks = [:]
         editLocalURLs = [:]
         editing = [:]
+        for handler in cancellationHandlers.values { handler() }
+        cancellationHandlers = [:]
         for task in downloadTasks.values { task.cancel() }
         downloadTasks = [:]
         let client = sftp

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -307,12 +307,13 @@ final class SFTPBrowser {
 
     /// Finder 拖出下载使用。拖拽开始时冻结 remoteDirectory,避免传输过程中切换目录后
     /// 同名文件被解析到新的当前位置。错误必须继续抛给 NSItemProvider,让 Finder 显示失败。
+    @discardableResult
     func downloadForDrag(
         _ entry: Entry,
         remoteDirectory: String,
         to localURL: URL,
         progress: Progress
-    ) async throws {
+    ) async throws -> SFTPDownloadEngine.SFTPDownloadResult {
         try await performDownload(
             entry,
             remoteDirectory: remoteDirectory,
@@ -321,12 +322,13 @@ final class SFTPBrowser {
         )
     }
 
+    @discardableResult
     private func performDownload(
         _ entry: Entry,
         remoteDirectory: String,
         to localURL: URL,
         externalProgress: Progress?
-    ) async throws {
+    ) async throws -> SFTPDownloadEngine.SFTPDownloadResult {
         // The top-level name is server-controlled too. Validate it before opening a handle or
         // touching the caller-provided local destination; recursive entries are validated by the
         // download engine while it builds the directory plan.
@@ -358,8 +360,9 @@ final class SFTPBrowser {
             }
         }
 
+        let copiedBytes: UInt64
         if entry.isDirectory {
-            _ = try await SFTPDownloadEngine.downloadDirectory(
+            let plan = try await SFTPDownloadEngine.downloadDirectory(
                 remoteRoot: remotePath,
                 localRoot: localURL,
                 sftp: sftp,
@@ -375,8 +378,9 @@ final class SFTPBrowser {
                 },
                 onProgress: onProgress
             )
+            copiedBytes = plan.copiedBytes
         } else {
-            _ = try await SFTPDownloadEngine.downloadFile(
+            copiedBytes = try await SFTPDownloadEngine.downloadFile(
                 remotePath: remotePath,
                 expectedSize: entry.sizeIsKnown ? entry.size : nil,
                 localURL: localURL,
@@ -386,6 +390,7 @@ final class SFTPBrowser {
                 onProgress: onProgress
             )
         }
+        return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: copiedBytes)
     }
 
     private static func saturatingAdd(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -417,10 +417,10 @@ final class SFTPBrowser {
         // The top-level name is server-controlled too. Validate it before opening a handle or
         // touching the caller-provided local destination; recursive entries are validated by the
         // download engine while it builds the directory plan.
+        try LocalPathComponentValidator.validateComponent(entry.name)
         if !isCustomDownloadExecutor {
             guard sftp != nil else { throw TransferError.sftpUnavailable }
         }
-        try LocalPathComponentValidator.validateComponent(entry.name)
 
         let remotePath = join(remoteDirectory, entry.name)
         let transferID = beginTransfer(

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -134,15 +134,34 @@ final class SFTPBrowser {
     init(
         initialPath: String? = nil,
         configuration: SFTPTransferConfiguration = .init(),
-        transferBudget: SFTPDownloadEngine.TransferBudget? = nil,
         opener: @escaping () async throws -> SFTPClient
     ) {
         let normalized = configuration.normalized
         self.initialPath = initialPath
         self.configuration = normalized
-        self.transferBudget = transferBudget ?? SFTPDownloadEngine.TransferBudget(configuration: normalized)
+        self.transferBudget = SFTPDownloadEngine.TransferBudget(configuration: normalized)
         self.opener = opener
     }
+
+    #if DEBUG
+    /// 测试专用初始化方法: 强制校验注入的 transferBudget 与 configuration 必须绝对一致
+    init(
+        initialPath: String? = nil,
+        configuration: SFTPTransferConfiguration,
+        testBudget: SFTPDownloadEngine.TransferBudget,
+        opener: @escaping () async throws -> SFTPClient
+    ) {
+        let normalized = configuration.normalized
+        precondition(
+            testBudget.configuration == normalized,
+            "TransferBudget configuration must match SFTPBrowser configuration"
+        )
+        self.initialPath = initialPath
+        self.configuration = normalized
+        self.transferBudget = testBudget
+        self.opener = opener
+    }
+    #endif
 
     /// 打开 SFTP 并列出 home 目录。子通道打开可能被服务器无响应地挂住
     /// (sshd 未启用 SFTP 子系统 / MaxSessions 限制),15s 看门狗置失败态可重试。
@@ -620,7 +639,9 @@ final class SFTPBrowser {
 
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("berth-edit-\(UUID().uuidString)", isDirectory: true)
-        let localURL = dir.appendingPathComponent(entry.name)
+        guard let localURL = try? LocalPathComponentValidator.safeURL(in: dir, component: entry.name) else {
+            return nil
+        }
         editLocalURLs[remotePath] = localURL
 
         editing[remotePath] = .syncing

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -110,6 +110,22 @@ final class SFTPBrowser {
         var label: String
         /// 0...1;nil 表示不确定(扫描中/体积未知)
         var progress: Double?
+        var isCancelling: Bool
+        var canCancel: Bool
+
+        init(
+            id: UUID,
+            label: String,
+            progress: Double? = nil,
+            isCancelling: Bool = false,
+            canCancel: Bool = false
+        ) {
+            self.id = id
+            self.label = label
+            self.progress = progress
+            self.isCancelling = isCancelling
+            self.canCancel = canCancel
+        }
     }
 
     private(set) var state: State = .idle
@@ -272,10 +288,70 @@ final class SFTPBrowser {
     /// 本地上传的读取块大小(256KB):摊薄往返开销,同时避免整文件读入内存
     private static let uploadChunkSize = 256 * 1024
 
-    private func beginTransfer(_ label: String, progress: Double? = nil) -> UUID {
+    private var downloadTasks: [UUID: Task<SFTPDownloadEngine.SFTPDownloadResult, Error>] = [:]
+
+    typealias DownloadExecutor = @Sendable (
+        _ entry: Entry,
+        _ remotePath: String,
+        _ localURL: URL,
+        _ sftp: SFTPClient?,
+        _ budget: SFTPDownloadEngine.TransferBudget,
+        _ configuration: SFTPTransferConfiguration,
+        _ onPlan: @escaping @Sendable (SFTPDownloadEngine.DirectoryPlan) async -> Void,
+        _ onProgress: @escaping @Sendable (SFTPDownloadEngine.ProgressUpdate) async -> Void
+    ) async throws -> SFTPDownloadEngine.SFTPDownloadResult
+
+    static let defaultDownloadExecutor: DownloadExecutor = { entry, remotePath, localURL, sftp, budget, configuration, onPlan, onProgress in
+        guard let sftp else { throw TransferError.sftpUnavailable }
+        if entry.isDirectory {
+            let plan = try await SFTPDownloadEngine.downloadDirectory(
+                remoteRoot: remotePath,
+                localRoot: localURL,
+                sftp: sftp,
+                budget: budget,
+                configuration: configuration,
+                onPlan: onPlan,
+                onProgress: onProgress
+            )
+            return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: plan.copiedBytes)
+        } else {
+            let copiedBytes = try await SFTPDownloadEngine.downloadFile(
+                remotePath: remotePath,
+                expectedSize: entry.sizeIsKnown ? entry.size : nil,
+                localURL: localURL,
+                sftp: sftp,
+                budget: budget,
+                configuration: configuration,
+                onProgress: onProgress
+            )
+            return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: copiedBytes)
+        }
+    }
+
+    private var isCustomDownloadExecutor = false
+    var downloadExecutor: DownloadExecutor = SFTPBrowser.defaultDownloadExecutor {
+        didSet {
+            isCustomDownloadExecutor = true
+        }
+    }
+
+    private func beginTransfer(_ label: String, progress: Double? = nil, canCancel: Bool = false) -> UUID {
         let id = UUID()
-        transfers.append(ActiveTransfer(id: id, label: label, progress: progress))
+        transfers.append(ActiveTransfer(
+            id: id,
+            label: label,
+            progress: progress,
+            isCancelling: false,
+            canCancel: canCancel
+        ))
         return id
+    }
+
+    func cancelTransfer(_ id: UUID) {
+        guard let index = transfers.firstIndex(where: { $0.id == id }) else { return }
+        guard transfers[index].canCancel, !transfers[index].isCancelling else { return }
+        transfers[index].isCancelling = true
+        downloadTasks[id]?.cancel()
     }
 
     private func setTransfer(_ id: UUID, label: String) {
@@ -300,6 +376,10 @@ final class SFTPBrowser {
                 to: localURL,
                 externalProgress: nil
             )
+        } catch is CancellationError {
+            // 用户主动取消, 不改变 state 为 .failed
+        } catch where (error as? CocoaError)?.code == .userCancelled {
+            // 用户主动取消
         } catch {
             state = .failed(friendly(error))
         }
@@ -332,17 +412,23 @@ final class SFTPBrowser {
         // The top-level name is server-controlled too. Validate it before opening a handle or
         // touching the caller-provided local destination; recursive entries are validated by the
         // download engine while it builds the directory plan.
+        if !isCustomDownloadExecutor {
+            guard sftp != nil else { throw TransferError.sftpUnavailable }
+        }
         try LocalPathComponentValidator.validateComponent(entry.name)
-        guard let sftp else { throw TransferError.sftpUnavailable }
 
         let remotePath = join(remoteDirectory, entry.name)
         let transferID = beginTransfer(
             entry.isDirectory
                 ? String(localized: "扫描 \(entry.name)…")
                 : String(localized: "下载 \(entry.name)…"),
-            progress: !entry.isDirectory && entry.size > 0 ? 0 : nil
+            progress: !entry.isDirectory && entry.size > 0 ? 0 : nil,
+            canCancel: true
         )
-        defer { endTransfer(transferID) }
+        defer {
+            downloadTasks.removeValue(forKey: transferID)
+            endTransfer(transferID)
+        }
         let sink = SFTPDownloadProgressSink(progress: externalProgress) { [weak self] update in
             guard let self else { return }
             if let totalBytes = update.totalBytes, totalBytes > 0 {
@@ -360,37 +446,39 @@ final class SFTPBrowser {
             }
         }
 
-        let copiedBytes: UInt64
-        if entry.isDirectory {
-            let plan = try await SFTPDownloadEngine.downloadDirectory(
-                remoteRoot: remotePath,
-                localRoot: localURL,
-                sftp: sftp,
-                budget: transferBudget,
-                configuration: configuration,
-                onPlan: { [weak self] plan in
-                    guard let self else { return }
-                    await MainActor.run {
-                        self.setTransfer(transferID, label: plan.skippedSymlinks > 0
-                            ? String(localized: "下载 \(entry.name)…(跳过 \(plan.skippedSymlinks) 个符号链接)")
-                            : String(localized: "下载 \(entry.name)…"))
-                    }
-                },
-                onProgress: onProgress
-            )
-            copiedBytes = plan.copiedBytes
-        } else {
-            copiedBytes = try await SFTPDownloadEngine.downloadFile(
-                remotePath: remotePath,
-                expectedSize: entry.sizeIsKnown ? entry.size : nil,
-                localURL: localURL,
-                sftp: sftp,
-                budget: transferBudget,
-                configuration: configuration,
-                onProgress: onProgress
+        let onPlan: @Sendable (SFTPDownloadEngine.DirectoryPlan) async -> Void = { [weak self] plan in
+            guard let self else { return }
+            await MainActor.run {
+                self.setTransfer(transferID, label: plan.skippedSymlinks > 0
+                    ? String(localized: "下载 \(entry.name)…(跳过 \(plan.skippedSymlinks) 个符号链接)")
+                    : String(localized: "下载 \(entry.name)…"))
+            }
+        }
+
+        let transferTask = Task { [weak self] () -> SFTPDownloadEngine.SFTPDownloadResult in
+            guard let self else { throw CancellationError() }
+            return try await self.downloadExecutor(
+                entry,
+                remotePath,
+                localURL,
+                self.sftp,
+                self.transferBudget,
+                self.configuration,
+                onPlan,
+                onProgress
             )
         }
-        return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: copiedBytes)
+        downloadTasks[transferID] = transferTask
+
+        if Task.isCancelled {
+            transferTask.cancel()
+        }
+
+        return try await withTaskCancellationHandler {
+            try await transferTask.value
+        } onCancel: {
+            transferTask.cancel()
+        }
     }
 
     private static func saturatingAdd(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
@@ -825,6 +913,8 @@ final class SFTPBrowser {
         editTasks = [:]
         editLocalURLs = [:]
         editing = [:]
+        for task in downloadTasks.values { task.cancel() }
+        downloadTasks = [:]
         let client = sftp
         sftp = nil
         Task.detached { try? await client?.close() }

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -148,6 +148,7 @@ final class SFTPBrowser {
     /// (sshd 未启用 SFTP 子系统 / MaxSessions 限制),15s 看门狗置失败态可重试。
     func start() async {
         guard sftp == nil, state != .loading else { return }
+        Task { _ = try? await SFTPDragStagingStore.shared.sweepStale() }
         state = .loading
         let opening = Task { try await self.opener() }
         let watchdog = Task { [weak self] in

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -39,6 +39,22 @@ private final class SFTPDownloadProgressSink {
     }
 }
 
+enum SFTPTransferCancellation {
+    static func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+        let nsError = error as NSError
+        return (nsError.domain == NSCocoaErrorDomain
+            && nsError.code == CocoaError.userCancelled.rawValue)
+            || Task.isCancelled
+    }
+
+    static func normalizedError(_ error: Error) -> Error {
+        isCancellation(error) ? CocoaError(.userCancelled) : error
+    }
+}
+
 /// SFTP 文件浏览:复用会话 SSHClient 打开 SFTP,维护当前目录与条目,提供上传/下载/增删改。
 @MainActor
 @Observable
@@ -291,50 +307,47 @@ final class SFTPBrowser {
     private var downloadTasks: [UUID: Task<SFTPDownloadEngine.SFTPDownloadResult, Error>] = [:]
     private var cancellationHandlers: [UUID: @Sendable () -> Void] = [:]
 
-    typealias DownloadExecutor = @Sendable (
-        _ entry: Entry,
-        _ remotePath: String,
-        _ localURL: URL,
-        _ sftp: SFTPClient?,
-        _ budget: SFTPDownloadEngine.TransferBudget,
-        _ configuration: SFTPTransferConfiguration,
-        _ onPlan: @escaping @Sendable (SFTPDownloadEngine.DirectoryPlan) async -> Void,
-        _ onProgress: @escaping @Sendable (SFTPDownloadEngine.ProgressUpdate) async -> Void
-    ) async throws -> SFTPDownloadEngine.SFTPDownloadResult
+    struct DownloadExecution {
+        let entry: Entry
+        let remotePath: String
+        let localURL: URL
+        let sftp: SFTPClient?
+        let budget: SFTPDownloadEngine.TransferBudget
+        let configuration: SFTPTransferConfiguration
+        let onPlan: @Sendable (SFTPDownloadEngine.DirectoryPlan) async -> Void
+        let onProgress: @Sendable (SFTPDownloadEngine.ProgressUpdate) async -> Void
+    }
 
-    static let defaultDownloadExecutor: DownloadExecutor = { entry, remotePath, localURL, sftp, budget, configuration, onPlan, onProgress in
-        guard let sftp else { throw TransferError.sftpUnavailable }
-        if entry.isDirectory {
+    typealias DownloadExecutor = @Sendable (DownloadExecution) async throws -> SFTPDownloadEngine.SFTPDownloadResult
+
+    static let defaultDownloadExecutor: DownloadExecutor = { request in
+        guard let sftp = request.sftp else { throw TransferError.sftpUnavailable }
+        if request.entry.isDirectory {
             let plan = try await SFTPDownloadEngine.downloadDirectory(
-                remoteRoot: remotePath,
-                localRoot: localURL,
+                remoteRoot: request.remotePath,
+                localRoot: request.localURL,
                 sftp: sftp,
-                budget: budget,
-                configuration: configuration,
-                onPlan: onPlan,
-                onProgress: onProgress
+                budget: request.budget,
+                configuration: request.configuration,
+                onPlan: request.onPlan,
+                onProgress: request.onProgress
             )
             return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: plan.copiedBytes)
         } else {
             let copiedBytes = try await SFTPDownloadEngine.downloadFile(
-                remotePath: remotePath,
-                expectedSize: entry.sizeIsKnown ? entry.size : nil,
-                localURL: localURL,
+                remotePath: request.remotePath,
+                expectedSize: request.entry.sizeIsKnown ? request.entry.size : nil,
+                localURL: request.localURL,
                 sftp: sftp,
-                budget: budget,
-                configuration: configuration,
-                onProgress: onProgress
+                budget: request.budget,
+                configuration: request.configuration,
+                onProgress: request.onProgress
             )
             return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: copiedBytes)
         }
     }
 
-    private var isCustomDownloadExecutor = false
-    var downloadExecutor: DownloadExecutor = SFTPBrowser.defaultDownloadExecutor {
-        didSet {
-            isCustomDownloadExecutor = true
-        }
-    }
+    var downloadExecutor: DownloadExecutor = SFTPBrowser.defaultDownloadExecutor
 
     private func beginTransfer(_ label: String, progress: Double? = nil, canCancel: Bool = false) -> UUID {
         let id = UUID()
@@ -381,10 +394,8 @@ final class SFTPBrowser {
                 to: localURL,
                 externalProgress: nil
             )
-        } catch is CancellationError {
+        } catch where SFTPTransferCancellation.isCancellation(error) {
             // 用户主动取消, 不改变 state 为 .failed
-        } catch where (error as? CocoaError)?.code == .userCancelled {
-            // 用户主动取消
         } catch {
             state = .failed(friendly(error))
         }
@@ -418,10 +429,6 @@ final class SFTPBrowser {
         // touching the caller-provided local destination; recursive entries are validated by the
         // download engine while it builds the directory plan.
         try LocalPathComponentValidator.validateComponent(entry.name)
-        if !isCustomDownloadExecutor {
-            guard sftp != nil else { throw TransferError.sftpUnavailable }
-        }
-
         let remotePath = join(remoteDirectory, entry.name)
         let transferID = beginTransfer(
             entry.isDirectory
@@ -458,16 +465,16 @@ final class SFTPBrowser {
 
         let transferTask = Task { [weak self] () -> SFTPDownloadEngine.SFTPDownloadResult in
             guard let self else { throw CancellationError() }
-            return try await self.downloadExecutor(
-                entry,
-                remotePath,
-                localURL,
-                self.sftp,
-                self.transferBudget,
-                self.configuration,
-                onPlan,
-                onProgress
-            )
+            return try await self.downloadExecutor(DownloadExecution(
+                entry: entry,
+                remotePath: remotePath,
+                localURL: localURL,
+                sftp: self.sftp,
+                budget: self.transferBudget,
+                configuration: self.configuration,
+                onPlan: onPlan,
+                onProgress: onProgress
+            ))
         }
         downloadTasks[transferID] = transferTask
         if let externalProgress {

--- a/Berth/Core/SSH/SFTPDownloadEngine.swift
+++ b/Berth/Core/SSH/SFTPDownloadEngine.swift
@@ -46,6 +46,15 @@ enum SFTPDownloadEngine {
         /// partial sum must never be presented as a complete progress denominator.
         var totalBytes: UInt64? = 0
         var skippedSymlinks = 0
+        /// 传输阶段所有文件实际成功写入本地的累计字节数
+        var copiedBytes: UInt64 = 0
+    }
+
+    struct SFTPDownloadResult: Sendable, Equatable {
+        let copiedBytes: UInt64
+        init(copiedBytes: UInt64) {
+            self.copiedBytes = copiedBytes
+        }
     }
 
     struct ProgressUpdate: Sendable, Equatable {
@@ -645,7 +654,7 @@ enum SFTPDownloadEngine {
         do {
             try materializeDirectories(plan.directories, localRoot: localRoot)
 
-            try await downloadFiles(
+            let copiedBytes = try await downloadFiles(
                 plan.files,
                 localRoot: localRoot,
                 sftp: sftp,
@@ -654,7 +663,9 @@ enum SFTPDownloadEngine {
                 reporter: reporter
             )
             await reporter.finish()
-            return plan
+            var finalPlan = plan
+            finalPlan.copiedBytes = copiedBytes
+            return finalPlan
         } catch {
             await reporter.cancelDelivery()
             throw error
@@ -729,11 +740,12 @@ enum SFTPDownloadEngine {
         configuration: Configuration,
         budget: TransferBudget,
         reporter: ProgressAccumulator
-    ) async throws {
-        guard !files.isEmpty else { return }
-        try await withThrowingTaskGroup(of: UInt64.self) { group in
+    ) async throws -> UInt64 {
+        guard !files.isEmpty else { return 0 }
+        return try await withThrowingTaskGroup(of: UInt64.self) { group in
             var nextIndex = 0
             var active = 0
+            var totalCopied: UInt64 = 0
 
             while nextIndex < files.count || active > 0 {
                 while active < configuration.maxConcurrentFiles, nextIndex < files.count {
@@ -760,10 +772,13 @@ enum SFTPDownloadEngine {
                 }
 
                 if active > 0 {
-                    _ = try await group.next()
+                    if let bytes = try await group.next() {
+                        totalCopied = saturatingAdd(totalCopied, bytes)
+                    }
                     active -= 1
                 }
             }
+            return totalCopied
         }
     }
 
@@ -860,7 +875,7 @@ enum SFTPDownloadEngine {
                 }
                 let activeHandles = await budget.currentHandleCount
                 let activeRequests = await budget.currentRequestCount
-                DebugLog.append("sftp file start name=\(localURL.lastPathComponent) size=\(size ?? 0) activeHandles=\(activeHandles) activeRequests=\(activeRequests)")
+                DebugLog.append("sftp file start name=\(LogSanitizer.safeFilename(localURL.lastPathComponent)) size=\(size ?? 0) activeHandles=\(activeHandles) activeRequests=\(activeRequests)")
                 if let size {
                     copied = try await copyKnownSize(
                         expectedSize: size,
@@ -890,10 +905,10 @@ enum SFTPDownloadEngine {
                     }
                 }
                 try localHandle.close()
-                DebugLog.append("sftp file done name=\(localURL.lastPathComponent) copied=\(copied)")
+                DebugLog.append("sftp file done name=\(LogSanitizer.safeFilename(localURL.lastPathComponent)) copied=\(copied)")
             } catch {
                 try? localHandle.close()
-                DebugLog.append("sftp file failed name=\(localURL.lastPathComponent) error=\(error)")
+                DebugLog.append("sftp file failed name=\(LogSanitizer.safeFilename(localURL.lastPathComponent)) error=\(error)")
                 throw error
             }
 

--- a/Berth/Core/SSH/SFTPDownloadEngine.swift
+++ b/Berth/Core/SSH/SFTPDownloadEngine.swift
@@ -663,7 +663,7 @@ enum SFTPDownloadEngine {
 
     /// 真实本地目录物化: 遍历 plan.directories 创建各级目录。
     /// plan.directories[0] 为 [] (root sentinel, 代表 localRoot 本身), 已在此前由 FileManager 创建, 予以跳过。
-    /// 其余非空 components 按顺序拼接创建。
+    /// 其余非空 components 经过严格校验后按顺序拼接创建。
     static func materializeDirectories(
         _ directories: [[String]],
         localRoot: URL

--- a/Berth/Core/SSH/SFTPDragRetentionPolicy.swift
+++ b/Berth/Core/SSH/SFTPDragRetentionPolicy.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// 统一的 Finder 拖拽下载 staging 保留期策略 (Heuristic Grace Period)。
+/// 注意: 由于 NSItemProvider 无法感知 Finder 等消费方何时真正完成对 staging 文件的读取与复制,
+/// 此处计算的保留期仅为根据载荷大小推断的预估消费窗口 (Estimated Consumption Window),
+/// 绝不代表消费方必定已复制完成。
+public struct SFTPDragRetentionPolicy: Sendable, Equatable {
+    public static let minimumGracePeriod: TimeInterval = 30 * 60 // 30 分钟基线
+    public static let estimatedBytesPerSecond: Double = 2 * 1024 * 1024 // 假定慢速目标至少 2 MiB/s
+
+    /// 计算指定 payloadBytes 的预估消费保留窗口。
+    /// 无论单文件还是文件夹，均采用统一的单一计算源。
+    public static func retentionInterval(payloadBytes: UInt64?) -> TimeInterval {
+        guard let payloadBytes, payloadBytes > 0 else {
+            return minimumGracePeriod
+        }
+        let estimatedSeconds = Double(payloadBytes) / estimatedBytesPerSecond
+        return max(minimumGracePeriod, estimatedSeconds)
+    }
+}

--- a/Berth/Core/SSH/SFTPDragRetentionPolicy.swift
+++ b/Berth/Core/SSH/SFTPDragRetentionPolicy.swift
@@ -4,6 +4,8 @@ import Foundation
 /// 注意: 由于 NSItemProvider 无法感知 Finder 等消费方何时真正完成对 staging 文件的读取与复制,
 /// 此处计算的保留期仅为根据载荷大小推断的预估消费窗口 (Estimated Consumption Window),
 /// 绝不代表消费方必定已复制完成。
+/// 为避免 Finder 仍在复制超大载荷时删除源数据，该窗口不设置固定上限；已交付数据可能保留数天，
+/// 但仍会依据 payloadBytes 得到有限的回收时间。
 public struct SFTPDragRetentionPolicy: Sendable, Equatable {
     public static let minimumGracePeriod: TimeInterval = 30 * 60 // 30 分钟基线
     public static let estimatedBytesPerSecond: Double = 2 * 1024 * 1024 // 假定慢速目标至少 2 MiB/s

--- a/Berth/Core/SSH/SFTPDragStagingStore.swift
+++ b/Berth/Core/SSH/SFTPDragStagingStore.swift
@@ -23,6 +23,7 @@ public struct StagingMarkerMetadata: Codable, Sendable, Equatable {
     public let payloadName: String
     public let isDirectory: Bool
     public var payloadBytes: UInt64?
+    public var orphanedAt: Date?
 
     public init(
         schemaVersion: Int = 1,
@@ -32,7 +33,8 @@ public struct StagingMarkerMetadata: Codable, Sendable, Equatable {
         deliveredAt: Date? = nil,
         payloadName: String,
         isDirectory: Bool,
-        payloadBytes: UInt64? = nil
+        payloadBytes: UInt64? = nil,
+        orphanedAt: Date? = nil
     ) {
         self.schemaVersion = schemaVersion
         self.id = id
@@ -42,6 +44,7 @@ public struct StagingMarkerMetadata: Codable, Sendable, Equatable {
         self.payloadName = payloadName
         self.isDirectory = isDirectory
         self.payloadBytes = payloadBytes
+        self.orphanedAt = orphanedAt
     }
 }
 
@@ -278,14 +281,32 @@ public actor SFTPDragStagingStore {
                     let retention = SFTPDragRetentionPolicy.retentionInterval(payloadBytes: metadata.payloadBytes)
                     shouldReclaim = now.timeIntervalSince(deliveredAt) >= retention
                 } else {
-                    // 未成功投递 (下载中或中断): 区分崩溃残留与存活进程
-                    let age = now.timeIntervalSince(metadata.createdAt)
-                    if age >= absoluteCeiling {
-                        shouldReclaim = true
-                    } else if metadata.pid != ProcessInfo.processInfo.processIdentifier {
-                        let isDead = !processLivenessChecker(metadata.pid)
-                        shouldReclaim = isDead || age >= interruptedGracePeriod
+                    // 未成功投递 (下载中或中断):
+                    if metadata.pid != ProcessInfo.processInfo.processIdentifier {
+                        let isAlive = processLivenessChecker(metadata.pid)
+                        if isAlive {
+                            // 核心安全保证: 只要所有者进程确认存活, 绝不删除! 无论 age 经过多久 (30min/2h/48h)
+                            if metadata.orphanedAt != nil {
+                                var updated = metadata
+                                updated.orphanedAt = nil
+                                updateMarker(updated, at: markerURL)
+                            }
+                            shouldReclaim = false
+                        } else {
+                            // 所有者进程已确认死亡: 必须以首次检测到死亡的 orphanedAt 为起点计算 grace period
+                            if let orphanedAt = metadata.orphanedAt {
+                                shouldReclaim = now.timeIntervalSince(orphanedAt) >= interruptedGracePeriod
+                            } else {
+                                // 首次检测到所有者死亡: 写入 orphanedAt 标记, 本次 sweep 绝不删除
+                                var updated = metadata
+                                updated.orphanedAt = now
+                                updateMarker(updated, at: markerURL)
+                                shouldReclaim = false
+                            }
+                        }
                     } else {
+                        // 同进程 (但已不在 activeLeases 中): 说明为此前崩溃或未正常清理的残留
+                        let age = now.timeIntervalSince(metadata.createdAt)
                         shouldReclaim = age >= interruptedGracePeriod
                     }
                 }
@@ -346,6 +367,14 @@ public actor SFTPDragStagingStore {
         guard let timestamp else { return false }
 
         return now.timeIntervalSince(timestamp) >= legacyGracePeriod
+    }
+
+    private func updateMarker(_ metadata: StagingMarkerMetadata, at markerURL: URL) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        if let data = try? encoder.encode(metadata) {
+            try? markerWriter(data, markerURL)
+        }
     }
 
     /// 严格安全检查并删除单个标准 staging root (必须含有 marker)

--- a/Berth/Core/SSH/SFTPDragStagingStore.swift
+++ b/Berth/Core/SSH/SFTPDragStagingStore.swift
@@ -22,6 +22,7 @@ public struct StagingMarkerMetadata: Codable, Sendable, Equatable {
     public var deliveredAt: Date?
     public let payloadName: String
     public let isDirectory: Bool
+    public var payloadBytes: Int64?
 
     public init(
         schemaVersion: Int = 1,
@@ -30,7 +31,8 @@ public struct StagingMarkerMetadata: Codable, Sendable, Equatable {
         createdAt: Date = Date(),
         deliveredAt: Date? = nil,
         payloadName: String,
-        isDirectory: Bool
+        isDirectory: Bool,
+        payloadBytes: Int64? = nil
     ) {
         self.schemaVersion = schemaVersion
         self.id = id
@@ -39,6 +41,7 @@ public struct StagingMarkerMetadata: Codable, Sendable, Equatable {
         self.deliveredAt = deliveredAt
         self.payloadName = payloadName
         self.isDirectory = isDirectory
+        self.payloadBytes = payloadBytes
     }
 }
 
@@ -46,59 +49,96 @@ public struct SweepResult: Sendable, Equatable {
     public let examinedCount: Int
     public let reclaimedCount: Int
     public let reclaimedBytes: Int64
+    public let reclaimedLegacyCount: Int
 
-    public init(examinedCount: Int, reclaimedCount: Int, reclaimedBytes: Int64) {
+    public init(
+        examinedCount: Int,
+        reclaimedCount: Int,
+        reclaimedBytes: Int64,
+        reclaimedLegacyCount: Int = 0
+    ) {
         self.examinedCount = examinedCount
         self.reclaimedCount = reclaimedCount
         self.reclaimedBytes = reclaimedBytes
+        self.reclaimedLegacyCount = reclaimedLegacyCount
     }
 }
 
 /// 管理 Finder 拖拽下载 staging 临时数据的完整所有权与跨进程生命周期。
 /// 保证:
 /// 1. 下载失败或取消时立即删除 staging root。
-/// 2. 交付成功后记录 deliveredAt, 并在宽限期后安全回收。
+/// 2. 交付成功后记录 deliveredAt 与传输字节数, 并在充分考虑慢速存储复制的宽限期后安全回收。
 /// 3. 进程异常退出或崩溃残留的 staging 在下次启动、新建拖拽或打开面板时安全 sweep。
 /// 4. 严苛的安全边界: 仅删除位于 staging 根目录下、以 Berth-Drag- 为前缀、
-///    含有合法 Berth marker、且符合 stale 条件的实体, 绝不盲目 glob 或跨越符号链接。
+///    UUID 格式严格校验、且符合 stale 条件的实体, 绝不盲目 glob 或跨越符号链接。
+/// 5. 针对 89076ef 以前创建的 markerless legacy staging, 仅在严格满足直接子目录、
+///    严格 UUID 名称格式、非符号链接、未越界且超过安全 TTL (默认 24h) 时才安全回收。
 public actor SFTPDragStagingStore {
     public static let shared = SFTPDragStagingStore()
 
     public static let markerFilename = ".berth-lease.json"
     public static let prefix = "Berth-Drag-"
 
+    public typealias ProcessLivenessChecker = @Sendable (Int32) -> Bool
+
+    /// 严格遵循 POSIX 语义的进程存活检测器:
+    /// kill(pid, 0) == 0: 进程存在
+    /// errno == EPERM: 进程存在(无发信号权限)
+    /// errno == ESRCH: 进程不存在
+    public static let defaultProcessLivenessChecker: ProcessLivenessChecker = { pid in
+        guard pid > 0 else { return false }
+        if kill(pid, 0) == 0 {
+            return true
+        }
+        return errno != ESRCH
+    }
+
     private let baseDirectory: URL
     private let fileManager = FileManager.default
     private var activeLeases: [UUID: SFTPDragStagingLease] = [:]
+    private var lastSweepDate: Date?
 
     public let deliveredGracePeriod: TimeInterval
     public let interruptedGracePeriod: TimeInterval
     public let absoluteCeiling: TimeInterval
+    public let legacyGracePeriod: TimeInterval
+    public let minimumSweepInterval: TimeInterval
+    private let processLivenessChecker: ProcessLivenessChecker
 
     public init(
         baseDirectory: URL = FileManager.default.temporaryDirectory,
         deliveredGracePeriod: TimeInterval = 30 * 60,
         interruptedGracePeriod: TimeInterval = 60 * 60,
-        absoluteCeiling: TimeInterval = 24 * 3600
+        absoluteCeiling: TimeInterval = 24 * 3600,
+        legacyGracePeriod: TimeInterval = 24 * 3600,
+        minimumSweepInterval: TimeInterval = 60,
+        processLivenessChecker: @escaping ProcessLivenessChecker = SFTPDragStagingStore.defaultProcessLivenessChecker
     ) {
         self.baseDirectory = baseDirectory
         self.deliveredGracePeriod = deliveredGracePeriod
         self.interruptedGracePeriod = interruptedGracePeriod
         self.absoluteCeiling = absoluteCeiling
+        self.legacyGracePeriod = legacyGracePeriod
+        self.minimumSweepInterval = minimumSweepInterval
+        self.processLivenessChecker = processLivenessChecker
     }
 
     /// 创建一个全新的 staging lease。
-    /// 在创建前执行一次轻量 sweep 回收陈旧残留。
+    /// 校验文件名有效性并根据节流间隔执行轻量 sweep。
     public func create(
         named: String,
         isDirectory: Bool,
         now: Date = Date()
     ) throws -> SFTPDragStagingLease {
-        _ = try? sweepStale(now: now)
+        try LocalPathComponentValidator.validateComponent(named)
+
+        if shouldSweep(now: now) {
+            _ = try? sweepStale(now: now, force: false)
+        }
 
         let id = UUID()
         let rootURL = baseDirectory.appendingPathComponent("\(Self.prefix)\(id.uuidString)", isDirectory: true)
-        let payloadURL = rootURL.appendingPathComponent(named, isDirectory: isDirectory)
+        let payloadURL = try LocalPathComponentValidator.safeURL(in: rootURL, component: named, isDirectory: isDirectory)
 
         try fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
         let metadata = StagingMarkerMetadata(
@@ -122,8 +162,8 @@ public actor SFTPDragStagingStore {
         return lease
     }
 
-    /// 标记 staging 已交付给 Finder。移除 active 状态, 并写入 delivered 时间戳。
-    public func markDelivered(_ lease: SFTPDragStagingLease, now: Date = Date()) {
+    /// 标记 staging 已交付给 Finder。移除 active 状态, 并记录 delivered 时间戳及实际载荷大小。
+    public func markDelivered(_ lease: SFTPDragStagingLease, payloadBytes: Int64? = nil, now: Date = Date()) {
         activeLeases.removeValue(forKey: lease.id)
         let markerURL = lease.rootURL.appendingPathComponent(Self.markerFilename, isDirectory: false)
         guard fileManager.fileExists(atPath: markerURL.path) else { return }
@@ -133,11 +173,14 @@ public actor SFTPDragStagingStore {
             decoder.dateDecodingStrategy = .iso8601
             var metadata = try decoder.decode(StagingMarkerMetadata.self, from: data)
             metadata.deliveredAt = now
+            if let payloadBytes {
+                metadata.payloadBytes = payloadBytes
+            }
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = .iso8601
             let updated = try encoder.encode(metadata)
             try updated.write(to: markerURL, options: .atomic)
-            DebugLog.append("drag staging delivered id=\(lease.id)")
+            DebugLog.append("drag staging delivered id=\(lease.id) bytes=\(payloadBytes ?? 0)")
         } catch {
             DebugLog.append("drag staging delivered update failed id=\(lease.id) error=\(error)")
         }
@@ -158,93 +201,142 @@ public actor SFTPDragStagingStore {
     }
 
     /// 扫描 baseDirectory, 回收陈旧、已超时交付或遗弃的 staging。
-    public func sweepStale(now: Date = Date()) throws -> SweepResult {
+    /// 支持节流 (force == false 时距离上次扫描小于 minimumSweepInterval 则跳过)。
+    @discardableResult
+    public func sweepStale(now: Date = Date(), force: Bool = true) throws -> SweepResult {
+        if !force && !shouldSweep(now: now) {
+            return SweepResult(examinedCount: 0, reclaimedCount: 0, reclaimedBytes: 0, reclaimedLegacyCount: 0)
+        }
+        lastSweepDate = now
+
         guard fileManager.fileExists(atPath: baseDirectory.path) else {
-            return SweepResult(examinedCount: 0, reclaimedCount: 0, reclaimedBytes: 0)
+            return SweepResult(examinedCount: 0, reclaimedCount: 0, reclaimedBytes: 0, reclaimedLegacyCount: 0)
         }
 
         let contents = try fileManager.contentsOfDirectory(
             at: baseDirectory,
-            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey, .contentModificationDateKey, .creationDateKey],
             options: [.skipsHiddenFiles]
         )
 
         var examined = 0
         var reclaimed = 0
         var reclaimedBytes: Int64 = 0
+        var reclaimedLegacy = 0
 
         for url in contents {
             guard url.lastPathComponent.hasPrefix(Self.prefix) else { continue }
             examined += 1
 
             // 1. 严格目录与符号链接检查
-            let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey, .contentModificationDateKey, .creationDateKey])
             guard values?.isDirectory == true, values?.isSymbolicLink != true else { continue }
 
-            // 2. 检查路径不越界
-            guard isPathWithinBase(url) else { continue }
+            // 2. 检查路径严格位于 base 内部
+            guard LocalPathComponentValidator.isStrictlyContained(candidate: url, within: baseDirectory) else { continue }
 
-            // 3. 检查并读取 Berth marker
+            // 3. 检查是否有 Berth marker
             let markerURL = url.appendingPathComponent(Self.markerFilename, isDirectory: false)
             let markerValues = try? markerURL.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
-            guard markerValues?.isRegularFile == true, markerValues?.isSymbolicLink != true else {
-                continue
-            }
-            guard let data = try? Data(contentsOf: markerURL) else { continue }
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            guard let metadata = try? decoder.decode(StagingMarkerMetadata.self, from: data) else {
-                continue
-            }
-            guard metadata.schemaVersion >= 1,
-                  url.lastPathComponent == "\(Self.prefix)\(metadata.id.uuidString)" else {
-                continue
-            }
 
-            // 4. 当前进程 active lease 绝不删除
-            guard activeLeases[metadata.id] == nil else { continue }
-
-            // 5. 判断是否达到 stale 条件
-            let shouldReclaim: Bool
-            if let deliveredAt = metadata.deliveredAt {
-                shouldReclaim = now.timeIntervalSince(deliveredAt) >= deliveredGracePeriod
-            } else {
-                let age = now.timeIntervalSince(metadata.createdAt)
-                if age >= absoluteCeiling {
-                    shouldReclaim = true
-                } else if metadata.pid != ProcessInfo.processInfo.processIdentifier {
-                    let isDead = kill(metadata.pid, 0) != 0
-                    shouldReclaim = isDead || age >= interruptedGracePeriod
-                } else {
-                    shouldReclaim = age >= interruptedGracePeriod
+            if markerValues?.isRegularFile == true, markerValues?.isSymbolicLink != true {
+                // 有 marker: 按标准 metadata 策略回收
+                guard let data = try? Data(contentsOf: markerURL) else { continue }
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+                guard let metadata = try? decoder.decode(StagingMarkerMetadata.self, from: data) else {
+                    continue
                 }
-            }
+                guard metadata.schemaVersion >= 1,
+                      url.lastPathComponent == "\(Self.prefix)\(metadata.id.uuidString)" else {
+                    continue
+                }
 
-            guard shouldReclaim else { continue }
+                // 当前进程 active lease 绝不删除
+                guard activeLeases[metadata.id] == nil else { continue }
 
-            // 6. 计算字节数并安全删除
-            let bytes = computeSize(of: url)
-            if safelyRemoveStagingRoot(url) {
-                reclaimed += 1
-                reclaimedBytes += bytes
+                let shouldReclaim: Bool
+                if let deliveredAt = metadata.deliveredAt {
+                    // 慢速目标动态宽限期: 假定至少 2 MB/s 写入, 大文件按体积延长保留
+                    let dynamicGrace = max(
+                        deliveredGracePeriod,
+                        TimeInterval(metadata.payloadBytes ?? 0) / (2 * 1024 * 1024)
+                    )
+                    shouldReclaim = now.timeIntervalSince(deliveredAt) >= dynamicGrace
+                } else {
+                    let age = now.timeIntervalSince(metadata.createdAt)
+                    if age >= absoluteCeiling {
+                        shouldReclaim = true
+                    } else if metadata.pid != ProcessInfo.processInfo.processIdentifier {
+                        let isDead = !processLivenessChecker(metadata.pid)
+                        shouldReclaim = isDead || age >= interruptedGracePeriod
+                    } else {
+                        shouldReclaim = age >= interruptedGracePeriod
+                    }
+                }
+
+                guard shouldReclaim else { continue }
+
+                let bytes = computeSize(of: url)
+                if safelyRemoveStagingRoot(url) {
+                    reclaimed += 1
+                    reclaimedBytes += bytes
+                }
+            } else {
+                // 无 marker: 严格检查是否为 89076ef 以前遗留的 legacy staging 候选
+                guard isValidLegacyCandidate(url: url, values: values, now: now) else { continue }
+
+                let bytes = computeSize(of: url)
+                if safelyRemoveLegacyStagingRoot(url) {
+                    reclaimed += 1
+                    reclaimedLegacy += 1
+                    reclaimedBytes += bytes
+                }
             }
         }
 
         let result = SweepResult(
             examinedCount: examined,
             reclaimedCount: reclaimed,
-            reclaimedBytes: reclaimedBytes
+            reclaimedBytes: reclaimedBytes,
+            reclaimedLegacyCount: reclaimedLegacy
         )
         if reclaimed > 0 {
-            DebugLog.append("drag staging sweep examined=\(examined) reclaimed=\(reclaimed) bytes=\(reclaimedBytes)")
+            DebugLog.append("drag staging sweep examined=\(examined) reclaimed=\(reclaimed) legacy=\(reclaimedLegacy) bytes=\(reclaimedBytes)")
         }
         return result
     }
 
-    /// 严格安全检查并删除单个 staging root
+    private func shouldSweep(now: Date) -> Bool {
+        guard let lastSweep = lastSweepDate else { return true }
+        return now.timeIntervalSince(lastSweep) >= minimumSweepInterval
+    }
+
+    /// 严格判断是否为旧版 (89076ef 之前) 遗留的无 marker staging 目录。
+    /// 必须同时满足:
+    /// 1. 名称严格匹配 Berth-Drag-<UUID> 且 <UUID> 为合法标准 UUID。
+    /// 2. 是真实目录且不是符号链接。
+    /// 3. 标准化路径严格在 baseDirectory 内部。
+    /// 4. 文件的创建或修改时间已超过 legacyGracePeriod (默认 24h)。
+    private func isValidLegacyCandidate(url: URL, values: URLResourceValues?, now: Date) -> Bool {
+        let name = url.lastPathComponent
+        guard name.hasPrefix(Self.prefix) else { return false }
+        let rawUUID = String(name.dropFirst(Self.prefix.count))
+        guard UUID(uuidString: rawUUID) != nil else { return false }
+
+        guard values?.isDirectory == true, values?.isSymbolicLink != true else { return false }
+        guard LocalPathComponentValidator.isStrictlyContained(candidate: url, within: baseDirectory) else { return false }
+
+        let timestamp = values?.contentModificationDate ?? values?.creationDate
+        guard let timestamp else { return false }
+
+        return now.timeIntervalSince(timestamp) >= legacyGracePeriod
+    }
+
+    /// 严格安全检查并删除单个标准 staging root (必须含有 marker)
     @discardableResult
     private func safelyRemoveStagingRoot(_ rootURL: URL) -> Bool {
-        guard isPathWithinBase(rootURL) else { return false }
+        guard LocalPathComponentValidator.isStrictlyContained(candidate: rootURL, within: baseDirectory) else { return false }
         guard rootURL.lastPathComponent.hasPrefix(Self.prefix) else { return false }
         let values = try? rootURL.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
         guard values?.isDirectory == true, values?.isSymbolicLink != true else { return false }
@@ -261,10 +353,26 @@ public actor SFTPDragStagingStore {
         }
     }
 
-    private func isPathWithinBase(_ url: URL) -> Bool {
-        let basePath = baseDirectory.standardizedFileURL.resolvingSymlinksInPath().path
-        let targetPath = url.standardizedFileURL.resolvingSymlinksInPath().path
-        return targetPath.hasPrefix(basePath + "/") || targetPath == basePath
+    /// 严格安全检查并删除经校验确认的 legacy 无 marker staging root
+    @discardableResult
+    private func safelyRemoveLegacyStagingRoot(_ rootURL: URL) -> Bool {
+        guard LocalPathComponentValidator.isStrictlyContained(candidate: rootURL, within: baseDirectory) else { return false }
+        let name = rootURL.lastPathComponent
+        guard name.hasPrefix(Self.prefix) else { return false }
+        let rawUUID = String(name.dropFirst(Self.prefix.count))
+        guard UUID(uuidString: rawUUID) != nil else { return false }
+
+        let values = try? rootURL.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+        guard values?.isDirectory == true, values?.isSymbolicLink != true else { return false }
+
+        do {
+            try fileManager.removeItem(at: rootURL)
+            DebugLog.append("legacy drag staging reclaimed url=\(rootURL.lastPathComponent)")
+            return true
+        } catch {
+            DebugLog.append("legacy drag staging remove failed url=\(rootURL.lastPathComponent) error=\(error)")
+            return false
+        }
     }
 
     private func computeSize(of url: URL) -> Int64 {

--- a/Berth/Core/SSH/SFTPDragStagingStore.swift
+++ b/Berth/Core/SSH/SFTPDragStagingStore.swift
@@ -22,7 +22,7 @@ public struct StagingMarkerMetadata: Codable, Sendable, Equatable {
     public var deliveredAt: Date?
     public let payloadName: String
     public let isDirectory: Bool
-    public var payloadBytes: Int64?
+    public var payloadBytes: UInt64?
 
     public init(
         schemaVersion: Int = 1,
@@ -32,7 +32,7 @@ public struct StagingMarkerMetadata: Codable, Sendable, Equatable {
         deliveredAt: Date? = nil,
         payloadName: String,
         isDirectory: Bool,
-        payloadBytes: Int64? = nil
+        payloadBytes: UInt64? = nil
     ) {
         self.schemaVersion = schemaVersion
         self.id = id
@@ -67,11 +67,12 @@ public struct SweepResult: Sendable, Equatable {
 /// 管理 Finder 拖拽下载 staging 临时数据的完整所有权与跨进程生命周期。
 /// 保证:
 /// 1. 下载失败或取消时立即删除 staging root。
-/// 2. 交付成功后记录 deliveredAt 与传输字节数, 并在充分考虑慢速存储复制的宽限期后安全回收。
-/// 3. 进程异常退出或崩溃残留的 staging 在下次启动、新建拖拽或打开面板时安全 sweep。
-/// 4. 严苛的安全边界: 仅删除位于 staging 根目录下、以 Berth-Drag- 为前缀、
+/// 2. 交付成功后更新 deliveredAt 与真实 payloadBytes, 严格先持久化落盘再更新内存 active 状态。
+/// 3. 单文件与文件夹统一采用 SFTPDragRetentionPolicy 预估消费保留窗口, 避免大文件/目录被提前回收。
+/// 4. 进程异常退出或崩溃残留的 staging 在下次启动、新建拖拽或打开面板时安全 sweep。
+/// 5. 严苛的安全边界: 仅删除位于 staging 根目录下、以 Berth-Drag- 为前缀、
 ///    UUID 格式严格校验、且符合 stale 条件的实体, 绝不盲目 glob 或跨越符号链接。
-/// 5. 针对 89076ef 以前创建的 markerless legacy staging, 仅在严格满足直接子目录、
+/// 6. 针对 89076ef 以前创建的 markerless legacy staging, 仅在严格满足直接子目录、
 ///    严格 UUID 名称格式、非符号链接、未越界且超过安全 TTL (默认 24h) 时才安全回收。
 public actor SFTPDragStagingStore {
     public static let shared = SFTPDragStagingStore()
@@ -80,6 +81,7 @@ public actor SFTPDragStagingStore {
     public static let prefix = "Berth-Drag-"
 
     public typealias ProcessLivenessChecker = @Sendable (Int32) -> Bool
+    public typealias MarkerWriter = @Sendable (Data, URL) throws -> Void
 
     /// 严格遵循 POSIX 语义的进程存活检测器:
     /// kill(pid, 0) == 0: 进程存在
@@ -93,6 +95,10 @@ public actor SFTPDragStagingStore {
         return errno != ESRCH
     }
 
+    public static let defaultMarkerWriter: MarkerWriter = { data, url in
+        try data.write(to: url, options: .atomic)
+    }
+
     private let baseDirectory: URL
     private let fileManager = FileManager.default
     private var activeLeases: [UUID: SFTPDragStagingLease] = [:]
@@ -104,6 +110,7 @@ public actor SFTPDragStagingStore {
     public let legacyGracePeriod: TimeInterval
     public let minimumSweepInterval: TimeInterval
     private let processLivenessChecker: ProcessLivenessChecker
+    private let markerWriter: MarkerWriter
 
     public init(
         baseDirectory: URL = FileManager.default.temporaryDirectory,
@@ -112,7 +119,8 @@ public actor SFTPDragStagingStore {
         absoluteCeiling: TimeInterval = 24 * 3600,
         legacyGracePeriod: TimeInterval = 24 * 3600,
         minimumSweepInterval: TimeInterval = 60,
-        processLivenessChecker: @escaping ProcessLivenessChecker = SFTPDragStagingStore.defaultProcessLivenessChecker
+        processLivenessChecker: @escaping ProcessLivenessChecker = SFTPDragStagingStore.defaultProcessLivenessChecker,
+        markerWriter: @escaping MarkerWriter = SFTPDragStagingStore.defaultMarkerWriter
     ) {
         self.baseDirectory = baseDirectory
         self.deliveredGracePeriod = deliveredGracePeriod
@@ -121,6 +129,7 @@ public actor SFTPDragStagingStore {
         self.legacyGracePeriod = legacyGracePeriod
         self.minimumSweepInterval = minimumSweepInterval
         self.processLivenessChecker = processLivenessChecker
+        self.markerWriter = markerWriter
     }
 
     /// 创建一个全新的 staging lease。
@@ -154,36 +163,44 @@ public actor SFTPDragStagingStore {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         let data = try encoder.encode(metadata)
-        try data.write(to: markerURL, options: .atomic)
+        try markerWriter(data, markerURL)
 
         let lease = SFTPDragStagingLease(id: id, rootURL: rootURL, payloadURL: payloadURL, createdAt: now)
         activeLeases[id] = lease
-        DebugLog.append("drag staging lease created id=\(id) name=\(named)")
+        DebugLog.append("drag staging lease created id=\(id) name=\(LogSanitizer.safeFilename(named))")
         return lease
     }
 
-    /// 标记 staging 已交付给 Finder。移除 active 状态, 并记录 delivered 时间戳及实际载荷大小。
-    public func markDelivered(_ lease: SFTPDragStagingLease, payloadBytes: Int64? = nil, now: Date = Date()) {
-        activeLeases.removeValue(forKey: lease.id)
+    /// 标记 staging 已交付给 Finder。
+    /// 严格事务语义: 先读取旧 marker, 更新 deliveredAt 与 payloadBytes 并持久化原子落盘。
+    /// 仅当磁盘持久化成功后, 才将内存中 activeLeases 移除。
+    /// 若写入失败, 抛出异常, 保持 active 保护状态由调用方安全清理, 绝不留下伪 delivered 态。
+    public func markDelivered(
+        _ lease: SFTPDragStagingLease,
+        payloadBytes: UInt64,
+        now: Date = Date()
+    ) throws {
         let markerURL = lease.rootURL.appendingPathComponent(Self.markerFilename, isDirectory: false)
-        guard fileManager.fileExists(atPath: markerURL.path) else { return }
-        do {
-            let data = try Data(contentsOf: markerURL)
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            var metadata = try decoder.decode(StagingMarkerMetadata.self, from: data)
-            metadata.deliveredAt = now
-            if let payloadBytes {
-                metadata.payloadBytes = payloadBytes
-            }
-            let encoder = JSONEncoder()
-            encoder.dateEncodingStrategy = .iso8601
-            let updated = try encoder.encode(metadata)
-            try updated.write(to: markerURL, options: .atomic)
-            DebugLog.append("drag staging delivered id=\(lease.id) bytes=\(payloadBytes ?? 0)")
-        } catch {
-            DebugLog.append("drag staging delivered update failed id=\(lease.id) error=\(error)")
+        guard fileManager.fileExists(atPath: markerURL.path) else {
+            throw CocoaError(.fileNoSuchFile)
         }
+        let data = try Data(contentsOf: markerURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        var metadata = try decoder.decode(StagingMarkerMetadata.self, from: data)
+        metadata.deliveredAt = now
+        metadata.payloadBytes = payloadBytes
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let updated = try encoder.encode(metadata)
+
+        // 注入式 marker writer 验证落盘
+        try markerWriter(updated, markerURL)
+
+        // 仅在落盘成功后更新内存状态
+        activeLeases.removeValue(forKey: lease.id)
+        DebugLog.append("drag staging delivered id=\(lease.id) bytes=\(payloadBytes)")
     }
 
     /// 下载失败或取消时立即删除 staging root。幂等安全。
@@ -257,13 +274,11 @@ public actor SFTPDragStagingStore {
 
                 let shouldReclaim: Bool
                 if let deliveredAt = metadata.deliveredAt {
-                    // 慢速目标动态宽限期: 假定至少 2 MB/s 写入, 大文件按体积延长保留
-                    let dynamicGrace = max(
-                        deliveredGracePeriod,
-                        TimeInterval(metadata.payloadBytes ?? 0) / (2 * 1024 * 1024)
-                    )
-                    shouldReclaim = now.timeIntervalSince(deliveredAt) >= dynamicGrace
+                    // 已投递给 Finder: 无论原进程是否存活, 均严格尊重单一来源 SFTPDragRetentionPolicy 窗口
+                    let retention = SFTPDragRetentionPolicy.retentionInterval(payloadBytes: metadata.payloadBytes)
+                    shouldReclaim = now.timeIntervalSince(deliveredAt) >= retention
                 } else {
+                    // 未成功投递 (下载中或中断): 区分崩溃残留与存活进程
                     let age = now.timeIntervalSince(metadata.createdAt)
                     if age >= absoluteCeiling {
                         shouldReclaim = true
@@ -348,7 +363,7 @@ public actor SFTPDragStagingStore {
             try fileManager.removeItem(at: rootURL)
             return true
         } catch {
-            DebugLog.append("drag staging remove failed url=\(rootURL.lastPathComponent) error=\(error)")
+            DebugLog.append("drag staging remove failed url=\(LogSanitizer.safeFilename(rootURL.lastPathComponent)) error=\(error)")
             return false
         }
     }
@@ -367,10 +382,10 @@ public actor SFTPDragStagingStore {
 
         do {
             try fileManager.removeItem(at: rootURL)
-            DebugLog.append("legacy drag staging reclaimed url=\(rootURL.lastPathComponent)")
+            DebugLog.append("legacy drag staging reclaimed url=\(LogSanitizer.safeFilename(rootURL.lastPathComponent))")
             return true
         } catch {
-            DebugLog.append("legacy drag staging remove failed url=\(rootURL.lastPathComponent) error=\(error)")
+            DebugLog.append("legacy drag staging remove failed url=\(LogSanitizer.safeFilename(rootURL.lastPathComponent)) error=\(error)")
             return false
         }
     }

--- a/Berth/Core/SSH/SFTPDragStagingStore.swift
+++ b/Berth/Core/SSH/SFTPDragStagingStore.swift
@@ -1,0 +1,286 @@
+import Foundation
+
+public struct SFTPDragStagingLease: Sendable, Equatable, Identifiable {
+    public let id: UUID
+    public let rootURL: URL
+    public let payloadURL: URL
+    public let createdAt: Date
+
+    public init(id: UUID, rootURL: URL, payloadURL: URL, createdAt: Date = Date()) {
+        self.id = id
+        self.rootURL = rootURL
+        self.payloadURL = payloadURL
+        self.createdAt = createdAt
+    }
+}
+
+public struct StagingMarkerMetadata: Codable, Sendable, Equatable {
+    public let schemaVersion: Int
+    public let id: UUID
+    public let pid: Int32
+    public let createdAt: Date
+    public var deliveredAt: Date?
+    public let payloadName: String
+    public let isDirectory: Bool
+
+    public init(
+        schemaVersion: Int = 1,
+        id: UUID,
+        pid: Int32 = ProcessInfo.processInfo.processIdentifier,
+        createdAt: Date = Date(),
+        deliveredAt: Date? = nil,
+        payloadName: String,
+        isDirectory: Bool
+    ) {
+        self.schemaVersion = schemaVersion
+        self.id = id
+        self.pid = pid
+        self.createdAt = createdAt
+        self.deliveredAt = deliveredAt
+        self.payloadName = payloadName
+        self.isDirectory = isDirectory
+    }
+}
+
+public struct SweepResult: Sendable, Equatable {
+    public let examinedCount: Int
+    public let reclaimedCount: Int
+    public let reclaimedBytes: Int64
+
+    public init(examinedCount: Int, reclaimedCount: Int, reclaimedBytes: Int64) {
+        self.examinedCount = examinedCount
+        self.reclaimedCount = reclaimedCount
+        self.reclaimedBytes = reclaimedBytes
+    }
+}
+
+/// 管理 Finder 拖拽下载 staging 临时数据的完整所有权与跨进程生命周期。
+/// 保证:
+/// 1. 下载失败或取消时立即删除 staging root。
+/// 2. 交付成功后记录 deliveredAt, 并在宽限期后安全回收。
+/// 3. 进程异常退出或崩溃残留的 staging 在下次启动、新建拖拽或打开面板时安全 sweep。
+/// 4. 严苛的安全边界: 仅删除位于 staging 根目录下、以 Berth-Drag- 为前缀、
+///    含有合法 Berth marker、且符合 stale 条件的实体, 绝不盲目 glob 或跨越符号链接。
+public actor SFTPDragStagingStore {
+    public static let shared = SFTPDragStagingStore()
+
+    public static let markerFilename = ".berth-lease.json"
+    public static let prefix = "Berth-Drag-"
+
+    private let baseDirectory: URL
+    private let fileManager = FileManager.default
+    private var activeLeases: [UUID: SFTPDragStagingLease] = [:]
+
+    public let deliveredGracePeriod: TimeInterval
+    public let interruptedGracePeriod: TimeInterval
+    public let absoluteCeiling: TimeInterval
+
+    public init(
+        baseDirectory: URL = FileManager.default.temporaryDirectory,
+        deliveredGracePeriod: TimeInterval = 30 * 60,
+        interruptedGracePeriod: TimeInterval = 60 * 60,
+        absoluteCeiling: TimeInterval = 24 * 3600
+    ) {
+        self.baseDirectory = baseDirectory
+        self.deliveredGracePeriod = deliveredGracePeriod
+        self.interruptedGracePeriod = interruptedGracePeriod
+        self.absoluteCeiling = absoluteCeiling
+    }
+
+    /// 创建一个全新的 staging lease。
+    /// 在创建前执行一次轻量 sweep 回收陈旧残留。
+    public func create(
+        named: String,
+        isDirectory: Bool,
+        now: Date = Date()
+    ) throws -> SFTPDragStagingLease {
+        _ = try? sweepStale(now: now)
+
+        let id = UUID()
+        let rootURL = baseDirectory.appendingPathComponent("\(Self.prefix)\(id.uuidString)", isDirectory: true)
+        let payloadURL = rootURL.appendingPathComponent(named, isDirectory: isDirectory)
+
+        try fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let metadata = StagingMarkerMetadata(
+            schemaVersion: 1,
+            id: id,
+            pid: ProcessInfo.processInfo.processIdentifier,
+            createdAt: now,
+            deliveredAt: nil,
+            payloadName: named,
+            isDirectory: isDirectory
+        )
+        let markerURL = rootURL.appendingPathComponent(Self.markerFilename, isDirectory: false)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(metadata)
+        try data.write(to: markerURL, options: .atomic)
+
+        let lease = SFTPDragStagingLease(id: id, rootURL: rootURL, payloadURL: payloadURL, createdAt: now)
+        activeLeases[id] = lease
+        DebugLog.append("drag staging lease created id=\(id) name=\(named)")
+        return lease
+    }
+
+    /// 标记 staging 已交付给 Finder。移除 active 状态, 并写入 delivered 时间戳。
+    public func markDelivered(_ lease: SFTPDragStagingLease, now: Date = Date()) {
+        activeLeases.removeValue(forKey: lease.id)
+        let markerURL = lease.rootURL.appendingPathComponent(Self.markerFilename, isDirectory: false)
+        guard fileManager.fileExists(atPath: markerURL.path) else { return }
+        do {
+            let data = try Data(contentsOf: markerURL)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            var metadata = try decoder.decode(StagingMarkerMetadata.self, from: data)
+            metadata.deliveredAt = now
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let updated = try encoder.encode(metadata)
+            try updated.write(to: markerURL, options: .atomic)
+            DebugLog.append("drag staging delivered id=\(lease.id)")
+        } catch {
+            DebugLog.append("drag staging delivered update failed id=\(lease.id) error=\(error)")
+        }
+    }
+
+    /// 下载失败或取消时立即删除 staging root。幂等安全。
+    public func discard(_ lease: SFTPDragStagingLease) {
+        activeLeases.removeValue(forKey: lease.id)
+        safelyRemoveStagingRoot(lease.rootURL)
+        DebugLog.append("drag staging discarded id=\(lease.id)")
+    }
+
+    /// 延迟任务或定时任务在交付宽限期后调用。如果该 lease 仍在 active 态则绝不删除。
+    public func discardIfDelivered(_ lease: SFTPDragStagingLease) {
+        guard activeLeases[lease.id] == nil else { return }
+        safelyRemoveStagingRoot(lease.rootURL)
+        DebugLog.append("drag staging delivered gc id=\(lease.id)")
+    }
+
+    /// 扫描 baseDirectory, 回收陈旧、已超时交付或遗弃的 staging。
+    public func sweepStale(now: Date = Date()) throws -> SweepResult {
+        guard fileManager.fileExists(atPath: baseDirectory.path) else {
+            return SweepResult(examinedCount: 0, reclaimedCount: 0, reclaimedBytes: 0)
+        }
+
+        let contents = try fileManager.contentsOfDirectory(
+            at: baseDirectory,
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles]
+        )
+
+        var examined = 0
+        var reclaimed = 0
+        var reclaimedBytes: Int64 = 0
+
+        for url in contents {
+            guard url.lastPathComponent.hasPrefix(Self.prefix) else { continue }
+            examined += 1
+
+            // 1. 严格目录与符号链接检查
+            let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            guard values?.isDirectory == true, values?.isSymbolicLink != true else { continue }
+
+            // 2. 检查路径不越界
+            guard isPathWithinBase(url) else { continue }
+
+            // 3. 检查并读取 Berth marker
+            let markerURL = url.appendingPathComponent(Self.markerFilename, isDirectory: false)
+            let markerValues = try? markerURL.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+            guard markerValues?.isRegularFile == true, markerValues?.isSymbolicLink != true else {
+                continue
+            }
+            guard let data = try? Data(contentsOf: markerURL) else { continue }
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            guard let metadata = try? decoder.decode(StagingMarkerMetadata.self, from: data) else {
+                continue
+            }
+            guard metadata.schemaVersion >= 1,
+                  url.lastPathComponent == "\(Self.prefix)\(metadata.id.uuidString)" else {
+                continue
+            }
+
+            // 4. 当前进程 active lease 绝不删除
+            guard activeLeases[metadata.id] == nil else { continue }
+
+            // 5. 判断是否达到 stale 条件
+            let shouldReclaim: Bool
+            if let deliveredAt = metadata.deliveredAt {
+                shouldReclaim = now.timeIntervalSince(deliveredAt) >= deliveredGracePeriod
+            } else {
+                let age = now.timeIntervalSince(metadata.createdAt)
+                if age >= absoluteCeiling {
+                    shouldReclaim = true
+                } else if metadata.pid != ProcessInfo.processInfo.processIdentifier {
+                    let isDead = kill(metadata.pid, 0) != 0
+                    shouldReclaim = isDead || age >= interruptedGracePeriod
+                } else {
+                    shouldReclaim = age >= interruptedGracePeriod
+                }
+            }
+
+            guard shouldReclaim else { continue }
+
+            // 6. 计算字节数并安全删除
+            let bytes = computeSize(of: url)
+            if safelyRemoveStagingRoot(url) {
+                reclaimed += 1
+                reclaimedBytes += bytes
+            }
+        }
+
+        let result = SweepResult(
+            examinedCount: examined,
+            reclaimedCount: reclaimed,
+            reclaimedBytes: reclaimedBytes
+        )
+        if reclaimed > 0 {
+            DebugLog.append("drag staging sweep examined=\(examined) reclaimed=\(reclaimed) bytes=\(reclaimedBytes)")
+        }
+        return result
+    }
+
+    /// 严格安全检查并删除单个 staging root
+    @discardableResult
+    private func safelyRemoveStagingRoot(_ rootURL: URL) -> Bool {
+        guard isPathWithinBase(rootURL) else { return false }
+        guard rootURL.lastPathComponent.hasPrefix(Self.prefix) else { return false }
+        let values = try? rootURL.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+        guard values?.isDirectory == true, values?.isSymbolicLink != true else { return false }
+
+        let markerURL = rootURL.appendingPathComponent(Self.markerFilename, isDirectory: false)
+        guard fileManager.fileExists(atPath: markerURL.path) else { return false }
+
+        do {
+            try fileManager.removeItem(at: rootURL)
+            return true
+        } catch {
+            DebugLog.append("drag staging remove failed url=\(rootURL.lastPathComponent) error=\(error)")
+            return false
+        }
+    }
+
+    private func isPathWithinBase(_ url: URL) -> Bool {
+        let basePath = baseDirectory.standardizedFileURL.resolvingSymlinksInPath().path
+        let targetPath = url.standardizedFileURL.resolvingSymlinksInPath().path
+        return targetPath.hasPrefix(basePath + "/") || targetPath == basePath
+    }
+
+    private func computeSize(of url: URL) -> Int64 {
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return 0 }
+
+        var total: Int64 = 0
+        for case let fileURL as URL in enumerator {
+            guard let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey]),
+                  values.isRegularFile == true,
+                  let size = values.fileSize else { continue }
+            total += Int64(size)
+        }
+        return total
+    }
+}

--- a/Berth/Core/SSH/SFTPDragStagingStore.swift
+++ b/Berth/Core/SSH/SFTPDragStagingStore.swift
@@ -107,9 +107,7 @@ public actor SFTPDragStagingStore {
     private var activeLeases: [UUID: SFTPDragStagingLease] = [:]
     private var lastSweepDate: Date?
 
-    public let deliveredGracePeriod: TimeInterval
     public let interruptedGracePeriod: TimeInterval
-    public let absoluteCeiling: TimeInterval
     public let legacyGracePeriod: TimeInterval
     public let minimumSweepInterval: TimeInterval
     private let processLivenessChecker: ProcessLivenessChecker
@@ -117,18 +115,14 @@ public actor SFTPDragStagingStore {
 
     public init(
         baseDirectory: URL = FileManager.default.temporaryDirectory,
-        deliveredGracePeriod: TimeInterval = 30 * 60,
         interruptedGracePeriod: TimeInterval = 60 * 60,
-        absoluteCeiling: TimeInterval = 24 * 3600,
         legacyGracePeriod: TimeInterval = 24 * 3600,
         minimumSweepInterval: TimeInterval = 60,
         processLivenessChecker: @escaping ProcessLivenessChecker = SFTPDragStagingStore.defaultProcessLivenessChecker,
         markerWriter: @escaping MarkerWriter = SFTPDragStagingStore.defaultMarkerWriter
     ) {
         self.baseDirectory = baseDirectory
-        self.deliveredGracePeriod = deliveredGracePeriod
         self.interruptedGracePeriod = interruptedGracePeriod
-        self.absoluteCeiling = absoluteCeiling
         self.legacyGracePeriod = legacyGracePeriod
         self.minimumSweepInterval = minimumSweepInterval
         self.processLivenessChecker = processLivenessChecker
@@ -153,20 +147,27 @@ public actor SFTPDragStagingStore {
         let payloadURL = try LocalPathComponentValidator.safeURL(in: rootURL, component: named, isDirectory: isDirectory)
 
         try fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
-        let metadata = StagingMarkerMetadata(
-            schemaVersion: 1,
-            id: id,
-            pid: ProcessInfo.processInfo.processIdentifier,
-            createdAt: now,
-            deliveredAt: nil,
-            payloadName: named,
-            isDirectory: isDirectory
-        )
-        let markerURL = rootURL.appendingPathComponent(Self.markerFilename, isDirectory: false)
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        let data = try encoder.encode(metadata)
-        try markerWriter(data, markerURL)
+        do {
+            let metadata = StagingMarkerMetadata(
+                schemaVersion: 1,
+                id: id,
+                pid: ProcessInfo.processInfo.processIdentifier,
+                createdAt: now,
+                deliveredAt: nil,
+                payloadName: named,
+                isDirectory: isDirectory
+            )
+            let markerURL = rootURL.appendingPathComponent(Self.markerFilename, isDirectory: false)
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(metadata)
+            try markerWriter(data, markerURL)
+        } catch {
+            // The root is private to this just-created lease. A markerless root would otherwise
+            // survive until the much longer legacy sweep window.
+            try? fileManager.removeItem(at: rootURL)
+            throw error
+        }
 
         let lease = SFTPDragStagingLease(id: id, rootURL: rootURL, payloadURL: payloadURL, createdAt: now)
         activeLeases[id] = lease

--- a/Berth/Core/SSH/SFTPDragStagingStore.swift
+++ b/Berth/Core/SSH/SFTPDragStagingStore.swift
@@ -2,12 +2,20 @@ import Foundation
 
 public struct SFTPDragStagingLease: Sendable, Equatable, Identifiable {
     public let id: UUID
+    public let ownerNonce: UUID
     public let rootURL: URL
     public let payloadURL: URL
     public let createdAt: Date
 
-    public init(id: UUID, rootURL: URL, payloadURL: URL, createdAt: Date = Date()) {
+    public init(
+        id: UUID,
+        ownerNonce: UUID,
+        rootURL: URL,
+        payloadURL: URL,
+        createdAt: Date = Date()
+    ) {
         self.id = id
+        self.ownerNonce = ownerNonce
         self.rootURL = rootURL
         self.payloadURL = payloadURL
         self.createdAt = createdAt
@@ -18,7 +26,9 @@ public struct StagingMarkerMetadata: Codable, Sendable, Equatable {
     public let schemaVersion: Int
     public let id: UUID
     public let pid: Int32
+    public let ownerNonce: UUID?
     public let createdAt: Date
+    public var heartbeatAt: Date?
     public var deliveredAt: Date?
     public let payloadName: String
     public let isDirectory: Bool
@@ -26,10 +36,12 @@ public struct StagingMarkerMetadata: Codable, Sendable, Equatable {
     public var orphanedAt: Date?
 
     public init(
-        schemaVersion: Int = 1,
+        schemaVersion: Int = 2,
         id: UUID,
         pid: Int32 = ProcessInfo.processInfo.processIdentifier,
+        ownerNonce: UUID? = nil,
         createdAt: Date = Date(),
+        heartbeatAt: Date? = nil,
         deliveredAt: Date? = nil,
         payloadName: String,
         isDirectory: Bool,
@@ -39,7 +51,9 @@ public struct StagingMarkerMetadata: Codable, Sendable, Equatable {
         self.schemaVersion = schemaVersion
         self.id = id
         self.pid = pid
+        self.ownerNonce = ownerNonce
         self.createdAt = createdAt
+        self.heartbeatAt = heartbeatAt
         self.deliveredAt = deliveredAt
         self.payloadName = payloadName
         self.isDirectory = isDirectory
@@ -52,18 +66,15 @@ public struct SweepResult: Sendable, Equatable {
     public let examinedCount: Int
     public let reclaimedCount: Int
     public let reclaimedBytes: Int64
-    public let reclaimedLegacyCount: Int
 
     public init(
         examinedCount: Int,
         reclaimedCount: Int,
-        reclaimedBytes: Int64,
-        reclaimedLegacyCount: Int = 0
+        reclaimedBytes: Int64
     ) {
         self.examinedCount = examinedCount
         self.reclaimedCount = reclaimedCount
         self.reclaimedBytes = reclaimedBytes
-        self.reclaimedLegacyCount = reclaimedLegacyCount
     }
 }
 
@@ -74,9 +85,8 @@ public struct SweepResult: Sendable, Equatable {
 /// 3. 单文件与文件夹统一采用 SFTPDragRetentionPolicy 预估消费保留窗口, 避免大文件/目录被提前回收。
 /// 4. 进程异常退出或崩溃残留的 staging 在下次启动、新建拖拽或打开面板时安全 sweep。
 /// 5. 严苛的安全边界: 仅删除位于 staging 根目录下、以 Berth-Drag- 为前缀、
-///    UUID 格式严格校验、且符合 stale 条件的实体, 绝不盲目 glob 或跨越符号链接。
-/// 6. 针对 89076ef 以前创建的 markerless legacy staging, 仅在严格满足直接子目录、
-///    严格 UUID 名称格式、非符号链接、未越界且超过安全 TTL (默认 24h) 时才安全回收。
+///    UUID 格式严格校验、marker 所有权匹配且符合 stale 条件的实体。无 marker
+///    目录一律保留，绝不靠名称猜测所有权或跨越符号链接。
 public actor SFTPDragStagingStore {
     public static let shared = SFTPDragStagingStore()
 
@@ -105,26 +115,33 @@ public actor SFTPDragStagingStore {
     private let baseDirectory: URL
     private let fileManager = FileManager.default
     private var activeLeases: [UUID: SFTPDragStagingLease] = [:]
+    private var heartbeatTasks: [UUID: Task<Void, Never>] = [:]
     private var lastSweepDate: Date?
 
     public let interruptedGracePeriod: TimeInterval
-    public let legacyGracePeriod: TimeInterval
     public let minimumSweepInterval: TimeInterval
+    public let heartbeatInterval: TimeInterval
+    public let heartbeatTimeout: TimeInterval
     private let processLivenessChecker: ProcessLivenessChecker
     private let markerWriter: MarkerWriter
+    private let ownerNonce: UUID
 
     public init(
         baseDirectory: URL = FileManager.default.temporaryDirectory,
         interruptedGracePeriod: TimeInterval = 60 * 60,
-        legacyGracePeriod: TimeInterval = 24 * 3600,
         minimumSweepInterval: TimeInterval = 60,
+        heartbeatInterval: TimeInterval = 60,
+        heartbeatTimeout: TimeInterval = 5 * 60,
+        ownerNonce: UUID = UUID(),
         processLivenessChecker: @escaping ProcessLivenessChecker = SFTPDragStagingStore.defaultProcessLivenessChecker,
         markerWriter: @escaping MarkerWriter = SFTPDragStagingStore.defaultMarkerWriter
     ) {
         self.baseDirectory = baseDirectory
         self.interruptedGracePeriod = interruptedGracePeriod
-        self.legacyGracePeriod = legacyGracePeriod
         self.minimumSweepInterval = minimumSweepInterval
+        self.heartbeatInterval = heartbeatInterval
+        self.heartbeatTimeout = heartbeatTimeout
+        self.ownerNonce = ownerNonce
         self.processLivenessChecker = processLivenessChecker
         self.markerWriter = markerWriter
     }
@@ -149,10 +166,12 @@ public actor SFTPDragStagingStore {
         try fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
         do {
             let metadata = StagingMarkerMetadata(
-                schemaVersion: 1,
+                schemaVersion: 2,
                 id: id,
                 pid: ProcessInfo.processInfo.processIdentifier,
+                ownerNonce: ownerNonce,
                 createdAt: now,
+                heartbeatAt: now,
                 deliveredAt: nil,
                 payloadName: named,
                 isDirectory: isDirectory
@@ -163,14 +182,21 @@ public actor SFTPDragStagingStore {
             let data = try encoder.encode(metadata)
             try markerWriter(data, markerURL)
         } catch {
-            // The root is private to this just-created lease. A markerless root would otherwise
-            // survive until the much longer legacy sweep window.
+            // The root is private to this just-created lease. Without a marker it can never be
+            // proven to belong to Berth and therefore cannot be reclaimed by a later sweep.
             try? fileManager.removeItem(at: rootURL)
             throw error
         }
 
-        let lease = SFTPDragStagingLease(id: id, rootURL: rootURL, payloadURL: payloadURL, createdAt: now)
+        let lease = SFTPDragStagingLease(
+            id: id,
+            ownerNonce: ownerNonce,
+            rootURL: rootURL,
+            payloadURL: payloadURL,
+            createdAt: now
+        )
         activeLeases[id] = lease
+        startHeartbeat(for: lease)
         DebugLog.append("drag staging lease created id=\(id) name=\(LogSanitizer.safeFilename(named))")
         return lease
     }
@@ -192,6 +218,11 @@ public actor SFTPDragStagingStore {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         var metadata = try decoder.decode(StagingMarkerMetadata.self, from: data)
+        guard metadata.schemaVersion == 2,
+              metadata.id == lease.id,
+              metadata.ownerNonce == lease.ownerNonce else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
         metadata.deliveredAt = now
         metadata.payloadBytes = payloadBytes
 
@@ -204,20 +235,22 @@ public actor SFTPDragStagingStore {
 
         // 仅在落盘成功后更新内存状态
         activeLeases.removeValue(forKey: lease.id)
+        stopHeartbeat(for: lease.id)
         DebugLog.append("drag staging delivered id=\(lease.id) bytes=\(payloadBytes)")
     }
 
     /// 下载失败或取消时立即删除 staging root。幂等安全。
     public func discard(_ lease: SFTPDragStagingLease) {
         activeLeases.removeValue(forKey: lease.id)
-        safelyRemoveStagingRoot(lease.rootURL)
+        stopHeartbeat(for: lease.id)
+        safelyRemoveStagingRoot(lease.rootURL, expectedLease: lease)
         DebugLog.append("drag staging discarded id=\(lease.id)")
     }
 
     /// 延迟任务或定时任务在交付宽限期后调用。如果该 lease 仍在 active 态则绝不删除。
     public func discardIfDelivered(_ lease: SFTPDragStagingLease) {
         guard activeLeases[lease.id] == nil else { return }
-        safelyRemoveStagingRoot(lease.rootURL)
+        safelyRemoveStagingRoot(lease.rootURL, expectedLease: lease)
         DebugLog.append("drag staging delivered gc id=\(lease.id)")
     }
 
@@ -226,31 +259,30 @@ public actor SFTPDragStagingStore {
     @discardableResult
     public func sweepStale(now: Date = Date(), force: Bool = true) throws -> SweepResult {
         if !force && !shouldSweep(now: now) {
-            return SweepResult(examinedCount: 0, reclaimedCount: 0, reclaimedBytes: 0, reclaimedLegacyCount: 0)
+            return SweepResult(examinedCount: 0, reclaimedCount: 0, reclaimedBytes: 0)
         }
         lastSweepDate = now
 
         guard fileManager.fileExists(atPath: baseDirectory.path) else {
-            return SweepResult(examinedCount: 0, reclaimedCount: 0, reclaimedBytes: 0, reclaimedLegacyCount: 0)
+            return SweepResult(examinedCount: 0, reclaimedCount: 0, reclaimedBytes: 0)
         }
 
         let contents = try fileManager.contentsOfDirectory(
             at: baseDirectory,
-            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey, .contentModificationDateKey, .creationDateKey],
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
             options: [.skipsHiddenFiles]
         )
 
         var examined = 0
         var reclaimed = 0
         var reclaimedBytes: Int64 = 0
-        var reclaimedLegacy = 0
 
         for url in contents {
             guard url.lastPathComponent.hasPrefix(Self.prefix) else { continue }
             examined += 1
 
             // 1. 严格目录与符号链接检查
-            let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey, .contentModificationDateKey, .creationDateKey])
+            let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
             guard values?.isDirectory == true, values?.isSymbolicLink != true else { continue }
 
             // 2. 检查路径严格位于 base 内部
@@ -260,86 +292,44 @@ public actor SFTPDragStagingStore {
             let markerURL = url.appendingPathComponent(Self.markerFilename, isDirectory: false)
             let markerValues = try? markerURL.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
 
-            if markerValues?.isRegularFile == true, markerValues?.isSymbolicLink != true {
-                // 有 marker: 按标准 metadata 策略回收
-                guard let data = try? Data(contentsOf: markerURL) else { continue }
-                let decoder = JSONDecoder()
-                decoder.dateDecodingStrategy = .iso8601
-                guard let metadata = try? decoder.decode(StagingMarkerMetadata.self, from: data) else {
-                    continue
-                }
-                guard metadata.schemaVersion >= 1,
-                      url.lastPathComponent == "\(Self.prefix)\(metadata.id.uuidString)" else {
-                    continue
-                }
+            // 名称不是所有权凭证。无 marker、符号链接 marker 或不可读 marker 都不能删除。
+            guard markerValues?.isRegularFile == true, markerValues?.isSymbolicLink != true,
+                  let metadata = readMarker(at: markerURL),
+                  (metadata.schemaVersion == 1 || metadata.schemaVersion == 2),
+                  url.lastPathComponent == "\(Self.prefix)\(metadata.id.uuidString)" else { continue }
 
-                // 当前进程 active lease 绝不删除
-                guard activeLeases[metadata.id] == nil else { continue }
+            // 当前 store 的 active lease 由内存状态直接保护。
+            guard activeLeases[metadata.id] == nil else { continue }
 
-                let shouldReclaim: Bool
-                if let deliveredAt = metadata.deliveredAt {
-                    // 已投递给 Finder: 无论原进程是否存活, 均严格尊重单一来源 SFTPDragRetentionPolicy 窗口
-                    let retention = SFTPDragRetentionPolicy.retentionInterval(payloadBytes: metadata.payloadBytes)
-                    shouldReclaim = now.timeIntervalSince(deliveredAt) >= retention
-                } else {
-                    // 未成功投递 (下载中或中断):
-                    if metadata.pid != ProcessInfo.processInfo.processIdentifier {
-                        let isAlive = processLivenessChecker(metadata.pid)
-                        if isAlive {
-                            // 核心安全保证: 只要所有者进程确认存活, 绝不删除! 无论 age 经过多久 (30min/2h/48h)
-                            if metadata.orphanedAt != nil {
-                                var updated = metadata
-                                updated.orphanedAt = nil
-                                updateMarker(updated, at: markerURL)
-                            }
-                            shouldReclaim = false
-                        } else {
-                            // 所有者进程已确认死亡: 必须以首次检测到死亡的 orphanedAt 为起点计算 grace period
-                            if let orphanedAt = metadata.orphanedAt {
-                                shouldReclaim = now.timeIntervalSince(orphanedAt) >= interruptedGracePeriod
-                            } else {
-                                // 首次检测到所有者死亡: 写入 orphanedAt 标记, 本次 sweep 绝不删除
-                                var updated = metadata
-                                updated.orphanedAt = now
-                                updateMarker(updated, at: markerURL)
-                                shouldReclaim = false
-                            }
-                        }
-                    } else {
-                        // 同进程 (但已不在 activeLeases 中): 说明为此前崩溃或未正常清理的残留
-                        let age = now.timeIntervalSince(metadata.createdAt)
-                        shouldReclaim = age >= interruptedGracePeriod
-                    }
-                }
-
-                guard shouldReclaim else { continue }
-
-                let bytes = computeSize(of: url)
-                if safelyRemoveStagingRoot(url) {
-                    reclaimed += 1
-                    reclaimedBytes += bytes
-                }
+            let shouldReclaim: Bool
+            if let deliveredAt = metadata.deliveredAt {
+                // 已投递给 Finder: 无论原进程是否存活, 均严格尊重单一 retention 策略。
+                let retention = SFTPDragRetentionPolicy.retentionInterval(payloadBytes: metadata.payloadBytes)
+                shouldReclaim = now.timeIntervalSince(deliveredAt) >= retention
             } else {
-                // 无 marker: 严格检查是否为 89076ef 以前遗留的 legacy staging 候选
-                guard isValidLegacyCandidate(url: url, values: values, now: now) else { continue }
+                shouldReclaim = shouldReclaimInterrupted(
+                    metadata,
+                    markerURL: markerURL,
+                    now: now
+                )
+            }
 
-                let bytes = computeSize(of: url)
-                if safelyRemoveLegacyStagingRoot(url) {
-                    reclaimed += 1
-                    reclaimedLegacy += 1
-                    reclaimedBytes += bytes
-                }
+            guard shouldReclaim else { continue }
+
+            let bytes = computeSize(of: url)
+            if safelyRemoveStagingRoot(url) {
+                reclaimed += 1
+                reclaimedBytes += bytes
             }
         }
 
         let result = SweepResult(
             examinedCount: examined,
             reclaimedCount: reclaimed,
-            reclaimedBytes: reclaimedBytes,
-            reclaimedLegacyCount: reclaimedLegacy
+            reclaimedBytes: reclaimedBytes
         )
         if reclaimed > 0 {
-            DebugLog.append("drag staging sweep examined=\(examined) reclaimed=\(reclaimed) legacy=\(reclaimedLegacy) bytes=\(reclaimedBytes)")
+            DebugLog.append("drag staging sweep examined=\(examined) reclaimed=\(reclaimed) bytes=\(reclaimedBytes)")
         }
         return result
     }
@@ -349,73 +339,139 @@ public actor SFTPDragStagingStore {
         return now.timeIntervalSince(lastSweep) >= minimumSweepInterval
     }
 
-    /// 严格判断是否为旧版 (89076ef 之前) 遗留的无 marker staging 目录。
-    /// 必须同时满足:
-    /// 1. 名称严格匹配 Berth-Drag-<UUID> 且 <UUID> 为合法标准 UUID。
-    /// 2. 是真实目录且不是符号链接。
-    /// 3. 标准化路径严格在 baseDirectory 内部。
-    /// 4. 文件的创建或修改时间已超过 legacyGracePeriod (默认 24h)。
-    private func isValidLegacyCandidate(url: URL, values: URLResourceValues?, now: Date) -> Bool {
-        let name = url.lastPathComponent
-        guard name.hasPrefix(Self.prefix) else { return false }
-        let rawUUID = String(name.dropFirst(Self.prefix.count))
-        guard UUID(uuidString: rawUUID) != nil else { return false }
+    private func shouldReclaimInterrupted(
+        _ metadata: StagingMarkerMetadata,
+        markerURL: URL,
+        now: Date
+    ) -> Bool {
+        let ownerAlive = processLivenessChecker(metadata.pid)
+        let heartbeatAge = metadata.heartbeatAt.map { max(0, now.timeIntervalSince($0)) }
 
-        guard values?.isDirectory == true, values?.isSymbolicLink != true else { return false }
-        guard LocalPathComponentValidator.isStrictlyContained(candidate: url, within: baseDirectory) else { return false }
+        // schema v1 没有 nonce/heartbeat。为了兼容已经落盘的 marker，只能保守地保护
+        // 存活 PID；所有新 lease 都使用下面可检测 PID 重用/停滞的 schema v2。
+        if metadata.schemaVersion == 1, ownerAlive {
+            return false
+        }
 
-        let timestamp = values?.contentModificationDate ?? values?.creationDate
-        guard let timestamp else { return false }
+        let belongsToThisStore = metadata.schemaVersion == 2
+            && metadata.pid == ProcessInfo.processInfo.processIdentifier
+            && metadata.ownerNonce == ownerNonce
+        let heartbeatIsFresh = metadata.schemaVersion == 2
+            && metadata.ownerNonce != nil
+            && heartbeatAge.map { $0 <= heartbeatTimeout } == true
 
-        return now.timeIntervalSince(timestamp) >= legacyGracePeriod
+        if !belongsToThisStore, ownerAlive, heartbeatIsFresh {
+            if metadata.orphanedAt != nil {
+                var updated = metadata
+                updated.orphanedAt = nil
+                _ = updateMarker(updated, at: markerURL)
+            }
+            return false
+        }
+
+        // 死亡进程、PID 已重用或 heartbeat 停滞都先进入 abandoned grace，绝不首次发现即删。
+        if let orphanedAt = metadata.orphanedAt {
+            let shouldReclaim = now.timeIntervalSince(orphanedAt) >= interruptedGracePeriod
+            DebugLog.append(
+                "drag staging interrupted id=\(metadata.id) ownerLive=\(ownerAlive) heartbeatAge=\(heartbeatAge ?? -1) reclaim=\(shouldReclaim)"
+            )
+            return shouldReclaim
+        }
+
+        var updated = metadata
+        updated.orphanedAt = now
+        _ = updateMarker(updated, at: markerURL)
+        return false
     }
 
-    private func updateMarker(_ metadata: StagingMarkerMetadata, at markerURL: URL) {
+    @discardableResult
+    private func updateMarker(_ metadata: StagingMarkerMetadata, at markerURL: URL) -> Bool {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
-        if let data = try? encoder.encode(metadata) {
-            try? markerWriter(data, markerURL)
+        do {
+            try markerWriter(encoder.encode(metadata), markerURL)
+            return true
+        } catch {
+            DebugLog.append("drag staging marker update failed id=\(metadata.id) error=\(error)")
+            return false
         }
+    }
+
+    private func readMarker(at markerURL: URL) -> StagingMarkerMetadata? {
+        guard let data = try? Data(contentsOf: markerURL) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(StagingMarkerMetadata.self, from: data)
+    }
+
+    private func startHeartbeat(for lease: SFTPDragStagingLease) {
+        let interval = heartbeatInterval
+        heartbeatTasks[lease.id]?.cancel()
+        heartbeatTasks[lease.id] = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(interval))
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled, let self else { return }
+                await self.persistHeartbeat(for: lease)
+            }
+        }
+    }
+
+    private func stopHeartbeat(for id: UUID) {
+        heartbeatTasks.removeValue(forKey: id)?.cancel()
+    }
+
+    private func persistHeartbeat(for lease: SFTPDragStagingLease, now: Date = Date()) {
+        guard activeLeases[lease.id]?.ownerNonce == lease.ownerNonce else {
+            stopHeartbeat(for: lease.id)
+            return
+        }
+        let markerURL = lease.rootURL.appendingPathComponent(Self.markerFilename, isDirectory: false)
+        guard var metadata = readMarker(at: markerURL),
+              metadata.schemaVersion == 2,
+              metadata.id == lease.id,
+              metadata.ownerNonce == lease.ownerNonce else {
+            DebugLog.append("drag staging heartbeat ownership mismatch id=\(lease.id)")
+            return
+        }
+        metadata.heartbeatAt = now
+        metadata.orphanedAt = nil
+        _ = updateMarker(metadata, at: markerURL)
     }
 
     /// 严格安全检查并删除单个标准 staging root (必须含有 marker)
     @discardableResult
-    private func safelyRemoveStagingRoot(_ rootURL: URL) -> Bool {
+    private func safelyRemoveStagingRoot(
+        _ rootURL: URL,
+        expectedLease: SFTPDragStagingLease? = nil
+    ) -> Bool {
         guard LocalPathComponentValidator.isStrictlyContained(candidate: rootURL, within: baseDirectory) else { return false }
-        guard rootURL.lastPathComponent.hasPrefix(Self.prefix) else { return false }
+        let name = rootURL.lastPathComponent
+        guard name.hasPrefix(Self.prefix),
+              let id = UUID(uuidString: String(name.dropFirst(Self.prefix.count))) else { return false }
         let values = try? rootURL.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
         guard values?.isDirectory == true, values?.isSymbolicLink != true else { return false }
 
         let markerURL = rootURL.appendingPathComponent(Self.markerFilename, isDirectory: false)
-        guard fileManager.fileExists(atPath: markerURL.path) else { return false }
+        let markerValues = try? markerURL.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+        guard markerValues?.isRegularFile == true, markerValues?.isSymbolicLink != true,
+              let metadata = readMarker(at: markerURL),
+              metadata.id == id,
+              metadata.schemaVersion == 1 || metadata.schemaVersion == 2 else { return false }
+        if let expectedLease {
+            guard metadata.id == expectedLease.id,
+                  metadata.schemaVersion == 2,
+                  metadata.ownerNonce == expectedLease.ownerNonce else { return false }
+        }
 
         do {
             try fileManager.removeItem(at: rootURL)
             return true
         } catch {
             DebugLog.append("drag staging remove failed url=\(LogSanitizer.safeFilename(rootURL.lastPathComponent)) error=\(error)")
-            return false
-        }
-    }
-
-    /// 严格安全检查并删除经校验确认的 legacy 无 marker staging root
-    @discardableResult
-    private func safelyRemoveLegacyStagingRoot(_ rootURL: URL) -> Bool {
-        guard LocalPathComponentValidator.isStrictlyContained(candidate: rootURL, within: baseDirectory) else { return false }
-        let name = rootURL.lastPathComponent
-        guard name.hasPrefix(Self.prefix) else { return false }
-        let rawUUID = String(name.dropFirst(Self.prefix.count))
-        guard UUID(uuidString: rawUUID) != nil else { return false }
-
-        let values = try? rootURL.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
-        guard values?.isDirectory == true, values?.isSymbolicLink != true else { return false }
-
-        do {
-            try fileManager.removeItem(at: rootURL)
-            DebugLog.append("legacy drag staging reclaimed url=\(LogSanitizer.safeFilename(rootURL.lastPathComponent))")
-            return true
-        } catch {
-            DebugLog.append("legacy drag staging remove failed url=\(LogSanitizer.safeFilename(rootURL.lastPathComponent)) error=\(error)")
             return false
         }
     }

--- a/Berth/Core/Services/LogSanitizer.swift
+++ b/Berth/Core/Services/LogSanitizer.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// 对不可信字符串 (如远端 SFTP 文件名、路径) 进行日志转义, 防止换行符伪造日志行或控制字符污染终端。
+public enum LogSanitizer {
+    /// 对字符串进行安全转义, 将 \n, \r, \t 及控制字符转义, 截断超长字符串。
+    public static func sanitize(_ text: String, maxLength: Int = 128) -> String {
+        var result = ""
+        result.reserveCapacity(min(text.count * 2, maxLength))
+        for scalar in text.unicodeScalars {
+            if result.count >= maxLength {
+                result.append("…")
+                break
+            }
+            switch scalar.value {
+            case 0x0A:
+                result.append("\\n")
+            case 0x0D:
+                result.append("\\r")
+            case 0x09:
+                result.append("\\t")
+            case 0x00...0x1F, 0x7F...0x9F:
+                result.append(String(format: "\\x%02X", scalar.value))
+            default:
+                result.unicodeScalars.append(scalar)
+            }
+        }
+        return result
+    }
+
+    /// 对远端文件名或路径进行安全转义, 仅提取 basename 并转义控制字符。
+    public static func safeFilename(_ name: String) -> String {
+        let basename = (name as NSString).lastPathComponent
+        let target = basename.isEmpty ? name : basename
+        return sanitize(target)
+    }
+}

--- a/Berth/Features/Terminal/SFTPDragProvider.swift
+++ b/Berth/Features/Terminal/SFTPDragProvider.swift
@@ -49,19 +49,19 @@ enum SFTPDragProvider {
                     guard let browser else {
                         throw CocoaError(.fileNoSuchFile)
                     }
-                    try await browser.downloadForDrag(
+                    let result = try await browser.downloadForDrag(
                         entry,
                         remoteDirectory: remoteDirectory,
                         to: lease.payloadURL,
                         progress: progress
                     )
-                    let payloadBytes = entry.isDirectory ? nil : Int64(entry.size)
-                    await SFTPDragStagingStore.shared.markDelivered(lease, payloadBytes: payloadBytes)
+                    try await SFTPDragStagingStore.shared.markDelivered(lease, payloadBytes: result.copiedBytes)
                     completion(lease.payloadURL, false, nil)
                     // 文件表示的接收方可能在 completion 返回后才开始复制。
-                    // 按体积动态计算宽限期 (基线 30 分钟, 慢速介质按 2 MB/s 上浮),
+                    // 依据实际成功写入本地的 payloadBytes, 通过统一策略源 SFTPDragRetentionPolicy
+                    // 计算预估消费窗口 (基线 30 分钟, 慢速介质按 2 MiB/s 延长),
                     // 再清理由 Berth 创建的临时副本; 启动/新拖拽时也会兜底 sweep。
-                    let retentionSeconds = max(30 * 60, TimeInterval(entry.size) / (2 * 1024 * 1024))
+                    let retentionSeconds = SFTPDragRetentionPolicy.retentionInterval(payloadBytes: result.copiedBytes)
                     Task.detached {
                         try? await Task.sleep(for: .seconds(retentionSeconds))
                         await SFTPDragStagingStore.shared.discardIfDelivered(lease)

--- a/Berth/Features/Terminal/SFTPDragProvider.swift
+++ b/Berth/Features/Terminal/SFTPDragProvider.swift
@@ -67,13 +67,40 @@ enum SFTPDragProvider {
                         await SFTPDragStagingStore.shared.discardIfDelivered(lease)
                     }
                 } catch {
-                    completion(nil, false, error)
                     await SFTPDragStagingStore.shared.discard(lease)
+                    let finalError = normalizedCancellationError(error)
+                    completion(nil, false, finalError)
                 }
             }
             progress.cancellationHandler = { task.cancel() }
             return progress
         }
         return provider
+    }
+
+    /// 判断是否为用户主动发起的取消操作 (覆盖 Swift.CancellationError, CocoaError(.userCancelled), Task.isCancelled)
+    static func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+        if let cocoa = error as? CocoaError, cocoa.code == .userCancelled {
+            return true
+        }
+        let nsError = error as NSError
+        if nsError.domain == NSCocoaErrorDomain && nsError.code == CocoaError.userCancelled.rawValue {
+            return true
+        }
+        if Task.isCancelled {
+            return true
+        }
+        return false
+    }
+
+    /// 将取消类错误标准化为 CocoaError(.userCancelled), 其余真实错误原样保留
+    static func normalizedCancellationError(_ error: Error) -> Error {
+        if isCancellation(error) {
+            return CocoaError(.userCancelled)
+        }
+        return error
     }
 }

--- a/Berth/Features/Terminal/SFTPDragProvider.swift
+++ b/Berth/Features/Terminal/SFTPDragProvider.swift
@@ -33,38 +33,39 @@ enum SFTPDragProvider {
         ) { completion in
             let total = !entry.isDirectory && entry.size > 0 ? Int64(clamping: entry.size) : 1
             let progress = Progress(totalUnitCount: total)
-            let task = Task { @MainActor in
-                let temporaryDirectory = FileManager.default.temporaryDirectory
-                    .appendingPathComponent("Berth-Drag-\(UUID().uuidString)", isDirectory: true)
-                let localURL = temporaryDirectory.appendingPathComponent(
-                    entry.name,
-                    isDirectory: entry.isDirectory
-                )
+            let task = Task {
+                let lease: SFTPDragStagingLease
+                do {
+                    lease = try await SFTPDragStagingStore.shared.create(
+                        named: entry.name,
+                        isDirectory: entry.isDirectory
+                    )
+                } catch {
+                    completion(nil, false, error)
+                    return
+                }
 
                 do {
                     guard let browser else {
                         throw CocoaError(.fileNoSuchFile)
                     }
-                    try FileManager.default.createDirectory(
-                        at: temporaryDirectory,
-                        withIntermediateDirectories: true
-                    )
                     try await browser.downloadForDrag(
                         entry,
                         remoteDirectory: remoteDirectory,
-                        to: localURL,
+                        to: lease.payloadURL,
                         progress: progress
                     )
-                    completion(localURL, false, nil)
+                    await SFTPDragStagingStore.shared.markDelivered(lease)
+                    completion(lease.payloadURL, false, nil)
                     // 文件表示的接收方可能在 completion 返回后才开始复制。给 Finder 足够的
-                    // 取用时间,再清理由 Berth 创建的临时副本;系统临时目录也会兜底清理。
+                    // 取用宽限期, 再清理由 Berth 创建的临时副本; 启动/新拖拽时也会兜底 sweep。
                     Task.detached {
                         try? await Task.sleep(for: .seconds(30 * 60))
-                        try? FileManager.default.removeItem(at: temporaryDirectory)
+                        await SFTPDragStagingStore.shared.discardIfDelivered(lease)
                     }
                 } catch {
                     completion(nil, false, error)
-                    try? FileManager.default.removeItem(at: temporaryDirectory)
+                    await SFTPDragStagingStore.shared.discard(lease)
                 }
             }
             progress.cancellationHandler = { task.cancel() }

--- a/Berth/Features/Terminal/SFTPDragProvider.swift
+++ b/Berth/Features/Terminal/SFTPDragProvider.swift
@@ -79,7 +79,7 @@ enum SFTPDragProvider {
     }
 
     /// 判断是否为用户主动发起的取消操作 (覆盖 Swift.CancellationError, CocoaError(.userCancelled), Task.isCancelled)
-    static func isCancellation(_ error: Error) -> Bool {
+    nonisolated static func isCancellation(_ error: Error) -> Bool {
         if error is CancellationError {
             return true
         }
@@ -97,7 +97,7 @@ enum SFTPDragProvider {
     }
 
     /// 将取消类错误标准化为 CocoaError(.userCancelled), 其余真实错误原样保留
-    static func normalizedCancellationError(_ error: Error) -> Error {
+    nonisolated static func normalizedCancellationError(_ error: Error) -> Error {
         if isCancellation(error) {
             return CocoaError(.userCancelled)
         }

--- a/Berth/Features/Terminal/SFTPDragProvider.swift
+++ b/Berth/Features/Terminal/SFTPDragProvider.swift
@@ -55,12 +55,15 @@ enum SFTPDragProvider {
                         to: lease.payloadURL,
                         progress: progress
                     )
-                    await SFTPDragStagingStore.shared.markDelivered(lease)
+                    let payloadBytes = entry.isDirectory ? nil : Int64(entry.size)
+                    await SFTPDragStagingStore.shared.markDelivered(lease, payloadBytes: payloadBytes)
                     completion(lease.payloadURL, false, nil)
-                    // 文件表示的接收方可能在 completion 返回后才开始复制。给 Finder 足够的
-                    // 取用宽限期, 再清理由 Berth 创建的临时副本; 启动/新拖拽时也会兜底 sweep。
+                    // 文件表示的接收方可能在 completion 返回后才开始复制。
+                    // 按体积动态计算宽限期 (基线 30 分钟, 慢速介质按 2 MB/s 上浮),
+                    // 再清理由 Berth 创建的临时副本; 启动/新拖拽时也会兜底 sweep。
+                    let retentionSeconds = max(30 * 60, TimeInterval(entry.size) / (2 * 1024 * 1024))
                     Task.detached {
-                        try? await Task.sleep(for: .seconds(30 * 60))
+                        try? await Task.sleep(for: .seconds(retentionSeconds))
                         await SFTPDragStagingStore.shared.discardIfDelivered(lease)
                     }
                 } catch {

--- a/Berth/Features/Terminal/SFTPDragProvider.swift
+++ b/Berth/Features/Terminal/SFTPDragProvider.swift
@@ -68,7 +68,7 @@ enum SFTPDragProvider {
                     }
                 } catch {
                     await SFTPDragStagingStore.shared.discard(lease)
-                    let finalError = normalizedCancellationError(error)
+                    let finalError = SFTPTransferCancellation.normalizedError(error)
                     completion(nil, false, finalError)
                 }
             }
@@ -78,29 +78,4 @@ enum SFTPDragProvider {
         return provider
     }
 
-    /// 判断是否为用户主动发起的取消操作 (覆盖 Swift.CancellationError, CocoaError(.userCancelled), Task.isCancelled)
-    nonisolated static func isCancellation(_ error: Error) -> Bool {
-        if error is CancellationError {
-            return true
-        }
-        if let cocoa = error as? CocoaError, cocoa.code == .userCancelled {
-            return true
-        }
-        let nsError = error as NSError
-        if nsError.domain == NSCocoaErrorDomain && nsError.code == CocoaError.userCancelled.rawValue {
-            return true
-        }
-        if Task.isCancelled {
-            return true
-        }
-        return false
-    }
-
-    /// 将取消类错误标准化为 CocoaError(.userCancelled), 其余真实错误原样保留
-    nonisolated static func normalizedCancellationError(_ error: Error) -> Error {
-        if isCancellation(error) {
-            return CocoaError(.userCancelled)
-        }
-        return error
-    }
 }

--- a/Berth/Features/Terminal/SFTPPanelView.swift
+++ b/Berth/Features/Terminal/SFTPPanelView.swift
@@ -363,19 +363,13 @@ struct SFTPPanelView: View {
                         }
                         if item.canCancel {
                             if item.isCancelling {
-                                ProgressView().controlSize(.mini)
+                                ProgressView()
+                                    .controlSize(.mini)
+                                    .frame(width: 18, height: 18)
                             } else {
-                                Button {
+                                TransferCancelButton {
                                     browser?.cancelTransfer(item.id)
-                                } label: {
-                                    Image(systemName: "xmark")
-                                        .font(.system(size: 9, weight: .bold))
-                                        .foregroundStyle(.secondary)
-                                        .frame(width: 14, height: 14)
-                                        .contentShape(Rectangle())
                                 }
-                                .buttonStyle(.plain)
-                                .help(String(localized: "取消传输"))
                             }
                         }
                     }
@@ -389,6 +383,30 @@ struct SFTPPanelView: View {
         }
         .padding(.horizontal, 12).padding(.vertical, 6)
         .background(theme.elevatedBackground)
+    }
+
+    private struct TransferCancelButton: View {
+        let action: () -> Void
+        @State private var isHovered = false
+
+        var body: some View {
+            Button(action: action) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(isHovered ? Color.primary : Color.secondary)
+                    .frame(width: 18, height: 18)
+                    .background {
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(isHovered ? Color.primary.opacity(0.10) : Color.clear)
+                    }
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                isHovered = hovering
+            }
+            .help(String(localized: "取消传输"))
+        }
     }
 
     private func centered<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {

--- a/Berth/Features/Terminal/SFTPPanelView.swift
+++ b/Berth/Features/Terminal/SFTPPanelView.swift
@@ -361,6 +361,23 @@ struct SFTPPanelView: View {
                                 .font(.system(size: 10, design: .monospaced))
                                 .foregroundStyle(.secondary)
                         }
+                        if item.canCancel {
+                            if item.isCancelling {
+                                ProgressView().controlSize(.mini)
+                            } else {
+                                Button {
+                                    browser?.cancelTransfer(item.id)
+                                } label: {
+                                    Image(systemName: "xmark")
+                                        .font(.system(size: 9, weight: .bold))
+                                        .foregroundStyle(.secondary)
+                                        .frame(width: 14, height: 14)
+                                        .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .help(String(localized: "取消传输"))
+                            }
+                        }
                     }
                     if let p = item.progress {
                         ProgressView(value: p)

--- a/Berth/Resources/Localizable.xcstrings
+++ b/Berth/Resources/Localizable.xcstrings
@@ -2966,6 +2966,16 @@
         }
       }
     },
+    "取消传输": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel Transfer"
+          }
+        }
+      }
+    },
     "取消收藏此目录": {
       "localizations": {
         "en": {

--- a/BerthTests/LocalPathComponentValidatorTests.swift
+++ b/BerthTests/LocalPathComponentValidatorTests.swift
@@ -54,4 +54,22 @@ final class LocalPathComponentValidatorTests: XCTestCase {
         XCTAssertFalse(LocalPathComponentValidator.isStrictlyContained(candidate: collision, within: root))
         XCTAssertFalse(LocalPathComponentValidator.isStrictlyContained(candidate: root, within: root))
     }
+
+    // MARK: - Log Sanitization Tests
+
+    func testLogSanitizerEscapesNewlinesAndControls() {
+        let malicious = "evil\n2026-09-03 ERROR fake injected log\r\tline"
+        let sanitized = LogSanitizer.sanitize(malicious)
+        XCTAssertFalse(sanitized.contains("\n"), "Must not contain raw newlines")
+        XCTAssertFalse(sanitized.contains("\r"), "Must not contain raw carriage returns")
+        XCTAssertTrue(sanitized.contains("\\n"), "Must escape newlines as \\n")
+        XCTAssertTrue(sanitized.contains("\\r"), "Must escape carriage returns as \\r")
+        XCTAssertTrue(sanitized.contains("\\t"), "Must escape tabs as \\t")
+
+        let filenameMalicious = "/some/remote/path/evil\nfile.txt"
+        let safeName = LogSanitizer.safeFilename(filenameMalicious)
+        XCTAssertFalse(safeName.contains("\n"))
+        XCTAssertFalse(safeName.contains("/some/remote/path"))
+        XCTAssertTrue(safeName.contains("evil\\nfile.txt"))
+    }
 }

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -900,4 +900,236 @@ final class SFTPBrowserTests: XCTestCase {
         let hundredGiB: UInt64 = 100 * 1024 * 1024 * 1024
         XCTAssertEqual(SFTPDragRetentionPolicy.retentionInterval(payloadBytes: hundredGiB), 51200)
     }
+
+    // MARK: - Download Cancellation Tests
+
+    func testSingleDownloadCancellation() async throws {
+        let browser = SFTPBrowser {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("test-cancel.bin")
+        let entry = SFTPBrowser.Entry(
+            name: "test-cancel.bin",
+            isDirectory: false,
+            isSymlink: false,
+            size: 1024,
+            sizeIsKnown: true,
+            modified: Date()
+        )
+
+        let started = expectation(description: "download started")
+        let wasCancelled = expectation(description: "download received cancellation")
+
+        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+            started.fulfill()
+            do {
+                try await Task.sleep(for: .seconds(5))
+                return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 1024)
+            } catch is CancellationError {
+                wasCancelled.fulfill()
+                throw CancellationError()
+            }
+        }
+
+        let downloadTask = Task {
+            await browser.download(entry, to: tempURL)
+        }
+
+        await fulfillment(of: [started], timeout: 2.0)
+        XCTAssertEqual(browser.transfers.count, 1)
+        let transfer = try XCTUnwrap(browser.transfers.first)
+        XCTAssertTrue(transfer.canCancel)
+        XCTAssertFalse(transfer.isCancelling)
+
+        // Cancel the transfer
+        browser.cancelTransfer(transfer.id)
+        XCTAssertTrue(browser.transfers.first?.isCancelling == true)
+
+        await fulfillment(of: [wasCancelled], timeout: 2.0)
+        await downloadTask.value
+
+        // Row removed and state is NOT failed
+        XCTAssertEqual(browser.transfers.count, 0)
+        if case .failed = browser.state {
+            XCTFail("Browser state must NOT be .failed when user cancels transfer")
+        }
+    }
+
+    func testMultiDownloadIndependentCancellation() async throws {
+        let browser = SFTPBrowser {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let entryA = SFTPBrowser.Entry(name: "fileA.bin", isDirectory: false, isSymlink: false, size: 100, sizeIsKnown: true, modified: Date())
+        let entryB = SFTPBrowser.Entry(name: "fileB.bin", isDirectory: false, isSymlink: false, size: 200, sizeIsKnown: true, modified: Date())
+
+        let startedA = expectation(description: "A started")
+        let startedB = expectation(description: "B started")
+        let completedA = expectation(description: "A completed")
+        let cancelledB = expectation(description: "B cancelled")
+
+        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+            if entry.name == "fileA.bin" {
+                startedA.fulfill()
+                try await Task.sleep(for: .milliseconds(300))
+                completedA.fulfill()
+                return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 100)
+            } else {
+                startedB.fulfill()
+                do {
+                    try await Task.sleep(for: .seconds(5))
+                    return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 200)
+                } catch is CancellationError {
+                    cancelledB.fulfill()
+                    throw CancellationError()
+                }
+            }
+        }
+
+        let taskA = Task { await browser.download(entryA, to: URL(fileURLWithPath: "/tmp/a")) }
+        let taskB = Task { await browser.download(entryB, to: URL(fileURLWithPath: "/tmp/b")) }
+
+        await fulfillment(of: [startedA, startedB], timeout: 2.0)
+        XCTAssertEqual(browser.transfers.count, 2)
+
+        let transferB = try XCTUnwrap(browser.transfers.first(where: { $0.label.contains("fileB") }))
+
+        // Cancel ONLY transfer B
+        browser.cancelTransfer(transferB.id)
+
+        await fulfillment(of: [cancelledB, completedA], timeout: 3.0)
+        await taskA.value
+        await taskB.value
+
+        XCTAssertEqual(browser.transfers.count, 0)
+        if case .failed = browser.state {
+            XCTFail("Neither cancelled B nor completed A should put browser in failed state")
+        }
+    }
+
+    func testCancellationPropagationFromOuterTask() async throws {
+        let browser = SFTPBrowser {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let entry = SFTPBrowser.Entry(name: "outer-cancel.bin", isDirectory: false, isSymlink: false, size: 500, sizeIsKnown: true, modified: Date())
+
+        let started = expectation(description: "transfer started")
+        let innerCancelled = expectation(description: "inner transfer task received cancellation")
+
+        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+            started.fulfill()
+            do {
+                try await Task.sleep(for: .seconds(5))
+                return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 500)
+            } catch is CancellationError {
+                innerCancelled.fulfill()
+                throw CancellationError()
+            }
+        }
+
+        let outerTask = Task {
+            try await browser.downloadForDrag(entry, remoteDirectory: "/remote", to: URL(fileURLWithPath: "/tmp/test"), progress: Progress())
+        }
+
+        await fulfillment(of: [started], timeout: 2.0)
+
+        // Cancel outer Task (simulating Progress.cancel() / Finder cancellation)
+        outerTask.cancel()
+
+        await fulfillment(of: [innerCancelled], timeout: 2.0)
+        do {
+            _ = try await outerTask.value
+            XCTFail("Outer task must throw CancellationError")
+        } catch is CancellationError {
+            // Expected
+        }
+        XCTAssertEqual(browser.transfers.count, 0)
+    }
+
+    func testDragDownloadCancellationCleansUpStagingRoot() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DragCancelTest-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let customStore = SFTPDragStagingStore(baseDirectory: tempDir)
+        let lease = try await customStore.create(named: "drag_cancel.bin", isDirectory: false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: lease.rootURL.path))
+
+        let browser = SFTPBrowser {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let entry = SFTPBrowser.Entry(name: "drag_cancel.bin", isDirectory: false, isSymlink: false, size: 100, sizeIsKnown: true, modified: Date())
+
+        let started = expectation(description: "drag download started")
+        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+            started.fulfill()
+            try await Task.sleep(for: .seconds(5))
+            return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 100)
+        }
+
+        let dragTask = Task {
+            do {
+                _ = try await browser.downloadForDrag(entry, remoteDirectory: "/remote", to: lease.payloadURL, progress: Progress())
+            } catch {
+                await customStore.discard(lease)
+                throw error
+            }
+        }
+
+        await fulfillment(of: [started], timeout: 2.0)
+        let transfer = try XCTUnwrap(browser.transfers.first)
+
+        // Cancel transfer from Berth UI
+        browser.cancelTransfer(transfer.id)
+
+        do {
+            _ = try await dragTask.value
+            XCTFail("Drag task should throw CancellationError")
+        } catch is CancellationError {
+            // Expected
+        }
+
+        // Verify staging directory was immediately cleaned up
+        XCTAssertFalse(FileManager.default.fileExists(atPath: lease.rootURL.path), "Staging root must be cleaned up on drag cancellation")
+    }
+
+    func testFolderScanningPhaseIsCancellable() async throws {
+        let browser = SFTPBrowser {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let dirEntry = SFTPBrowser.Entry(name: "deep-folder", isDirectory: true, isSymlink: false, size: 0, sizeIsKnown: false, modified: Date())
+
+        let scanningStarted = expectation(description: "scanning started")
+        let scanningCancelled = expectation(description: "scanning cancelled")
+
+        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+            scanningStarted.fulfill()
+            do {
+                try await Task.sleep(for: .seconds(5))
+                return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 0)
+            } catch is CancellationError {
+                scanningCancelled.fulfill()
+                throw CancellationError()
+            }
+        }
+
+        let downloadTask = Task {
+            await browser.download(dirEntry, to: URL(fileURLWithPath: "/tmp/folder"))
+        }
+
+        await fulfillment(of: [scanningStarted], timeout: 2.0)
+        let transfer = try XCTUnwrap(browser.transfers.first)
+        XCTAssertTrue(transfer.canCancel)
+        XCTAssertEqual(transfer.label, "扫描 deep-folder…")
+
+        // Cancel during scanning
+        browser.cancelTransfer(transfer.id)
+
+        await fulfillment(of: [scanningCancelled], timeout: 2.0)
+        await downloadTask.value
+        XCTAssertEqual(browser.transfers.count, 0)
+        if case .failed = browser.state {
+            XCTFail("Browser state must NOT be .failed when scanning is cancelled")
+        }
+    }
 }

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -920,7 +920,7 @@ final class SFTPBrowserTests: XCTestCase {
         let started = expectation(description: "download started")
         let wasCancelled = expectation(description: "download received cancellation")
 
-        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+        browser.downloadExecutor = { _ in
             started.fulfill()
             do {
                 try await Task.sleep(for: .seconds(5))
@@ -967,8 +967,8 @@ final class SFTPBrowserTests: XCTestCase {
         let completedA = expectation(description: "A completed")
         let cancelledB = expectation(description: "B cancelled")
 
-        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
-            if entry.name == "fileA.bin" {
+        browser.downloadExecutor = { request in
+            if request.entry.name == "fileA.bin" {
                 startedA.fulfill()
                 try await Task.sleep(for: .milliseconds(300))
                 completedA.fulfill()
@@ -1015,7 +1015,7 @@ final class SFTPBrowserTests: XCTestCase {
         let started = expectation(description: "transfer started")
         let innerCancelled = expectation(description: "inner transfer task received cancellation")
 
-        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+        browser.downloadExecutor = { _ in
             started.fulfill()
             do {
                 try await Task.sleep(for: .seconds(5))
@@ -1061,7 +1061,7 @@ final class SFTPBrowserTests: XCTestCase {
         let entry = SFTPBrowser.Entry(name: "drag_cancel.bin", isDirectory: false, isSymlink: false, size: 100, sizeIsKnown: true, modified: Date())
 
         let started = expectation(description: "drag download started")
-        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+        browser.downloadExecutor = { _ in
             started.fulfill()
             try await Task.sleep(for: .seconds(5))
             return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 100)
@@ -1102,7 +1102,7 @@ final class SFTPBrowserTests: XCTestCase {
         let scanningStarted = expectation(description: "scanning started")
         let scanningCancelled = expectation(description: "scanning cancelled")
 
-        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+        browser.downloadExecutor = { _ in
             scanningStarted.fulfill()
             do {
                 try await Task.sleep(for: .seconds(5))
@@ -1136,21 +1136,21 @@ final class SFTPBrowserTests: XCTestCase {
     func testDragCancellationErrorNormalization() {
         // Swift.CancellationError normalized to CocoaError.userCancelled
         let swiftCancel = CancellationError()
-        let normalized = SFTPDragProvider.normalizedCancellationError(swiftCancel)
+        let normalized = SFTPTransferCancellation.normalizedError(swiftCancel)
         XCTAssertTrue(normalized is CocoaError)
         XCTAssertEqual((normalized as? CocoaError)?.code, CocoaError.Code.userCancelled)
 
         // CocoaError.userCancelled stays CocoaError.userCancelled
         let cocoaCancel = CocoaError(.userCancelled)
-        XCTAssertEqual((SFTPDragProvider.normalizedCancellationError(cocoaCancel) as? CocoaError)?.code, .userCancelled)
+        XCTAssertEqual((SFTPTransferCancellation.normalizedError(cocoaCancel) as? CocoaError)?.code, .userCancelled)
 
         // Real error is preserved and NOT converted
         let notFound = CocoaError(.fileNoSuchFile)
-        let normalizedNotFound = SFTPDragProvider.normalizedCancellationError(notFound)
+        let normalizedNotFound = SFTPTransferCancellation.normalizedError(notFound)
         XCTAssertEqual((normalizedNotFound as? CocoaError)?.code, .fileNoSuchFile)
 
         let posixError = POSIXError(.EACCES)
-        let normalizedPosix = SFTPDragProvider.normalizedCancellationError(posixError)
+        let normalizedPosix = SFTPTransferCancellation.normalizedError(posixError)
         XCTAssertTrue(normalizedPosix is POSIXError)
         XCTAssertEqual((normalizedPosix as? POSIXError)?.code, .EACCES)
     }
@@ -1169,7 +1169,7 @@ final class SFTPBrowserTests: XCTestCase {
             progressCancelled.fulfill()
         }
 
-        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+        browser.downloadExecutor = { _ in
             started.fulfill()
             try await Task.sleep(for: .seconds(5))
             return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 1000)
@@ -1218,7 +1218,7 @@ final class SFTPBrowserTests: XCTestCase {
         let progress = Progress(totalUnitCount: 1)
 
         let started = expectation(description: "scan started")
-        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+        browser.downloadExecutor = { _ in
             started.fulfill()
             try await Task.sleep(for: .seconds(5))
             return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 0)
@@ -1230,7 +1230,7 @@ final class SFTPBrowserTests: XCTestCase {
                 _ = try await browser.downloadForDrag(entry, remoteDirectory: "/remote", to: lease.payloadURL, progress: progress)
             } catch {
                 await customStore.discard(lease)
-                let finalError = SFTPDragProvider.normalizedCancellationError(error)
+                let finalError = SFTPTransferCancellation.normalizedError(error)
                 completionError = finalError
                 throw finalError
             }

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -855,7 +855,6 @@ final class SFTPBrowserTests: XCTestCase {
             }
         }
     }
-
     @MainActor
     func testDragDownloadRejectsUnsafeTopLevelNameBeforeSFTPAccess() async {
         let browser = SFTPBrowser {
@@ -887,5 +886,4 @@ final class SFTPBrowserTests: XCTestCase {
         }
         XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
     }
-
 }

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -1132,4 +1132,129 @@ final class SFTPBrowserTests: XCTestCase {
             XCTFail("Browser state must NOT be .failed when scanning is cancelled")
         }
     }
+
+    func testDragCancellationErrorNormalization() {
+        // Swift.CancellationError normalized to CocoaError.userCancelled
+        let swiftCancel = CancellationError()
+        let normalized = SFTPDragProvider.normalizedCancellationError(swiftCancel)
+        XCTAssertTrue(normalized is CocoaError)
+        XCTAssertEqual((normalized as? CocoaError)?.code, CocoaError.Code.userCancelled)
+
+        // CocoaError.userCancelled stays CocoaError.userCancelled
+        let cocoaCancel = CocoaError(.userCancelled)
+        XCTAssertEqual((SFTPDragProvider.normalizedCancellationError(cocoaCancel) as? CocoaError)?.code, .userCancelled)
+
+        // Real error is preserved and NOT converted
+        let notFound = CocoaError(.fileNoSuchFile)
+        let normalizedNotFound = SFTPDragProvider.normalizedCancellationError(notFound)
+        XCTAssertEqual((normalizedNotFound as? CocoaError)?.code, .fileNoSuchFile)
+
+        let posixError = POSIXError(.EACCES)
+        let normalizedPosix = SFTPDragProvider.normalizedCancellationError(posixError)
+        XCTAssertTrue(normalizedPosix is POSIXError)
+        XCTAssertEqual((normalizedPosix as? POSIXError)?.code, .EACCES)
+    }
+
+    func testBerthUICancelPropagatesToExternalProgress() async throws {
+        let browser = SFTPBrowser {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let entry = SFTPBrowser.Entry(name: "drag-progress.bin", isDirectory: false, isSymlink: false, size: 1000, sizeIsKnown: true, modified: Date())
+        let progress = Progress(totalUnitCount: 1000)
+
+        let started = expectation(description: "download started")
+        let progressCancelled = expectation(description: "external progress cancelled")
+
+        progress.cancellationHandler = {
+            progressCancelled.fulfill()
+        }
+
+        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+            started.fulfill()
+            try await Task.sleep(for: .seconds(5))
+            return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 1000)
+        }
+
+        let downloadTask = Task {
+            try await browser.downloadForDrag(
+                entry,
+                remoteDirectory: "/remote",
+                to: URL(fileURLWithPath: "/tmp/dest"),
+                progress: progress
+            )
+        }
+
+        await fulfillment(of: [started], timeout: 2.0)
+        let transfer = try XCTUnwrap(browser.transfers.first)
+
+        // Berth UI cancel button clicked
+        browser.cancelTransfer(transfer.id)
+
+        // Must trigger externalProgress.cancel() and its cancellationHandler
+        await fulfillment(of: [progressCancelled], timeout: 2.0)
+
+        do {
+            _ = try await downloadTask.value
+            XCTFail("Download task must throw CancellationError")
+        } catch is CancellationError {
+            // Expected
+        }
+    }
+
+    func testScanningCancellationStagingCleanupAndNormalization() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ScanCancelTest-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let customStore = SFTPDragStagingStore(baseDirectory: tempDir)
+        let lease = try await customStore.create(named: "scan_cancel_folder", isDirectory: true)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: lease.rootURL.path))
+
+        let browser = SFTPBrowser {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let entry = SFTPBrowser.Entry(name: "scan_cancel_folder", isDirectory: true, isSymlink: false, size: 0, sizeIsKnown: false, modified: Date())
+        let progress = Progress(totalUnitCount: 1)
+
+        let started = expectation(description: "scan started")
+        browser.downloadExecutor = { entry, remotePath, localURL, sftp, budget, config, onPlan, onProgress in
+            started.fulfill()
+            try await Task.sleep(for: .seconds(5))
+            return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 0)
+        }
+
+        var completionError: Error?
+        let dragTask = Task {
+            do {
+                _ = try await browser.downloadForDrag(entry, remoteDirectory: "/remote", to: lease.payloadURL, progress: progress)
+            } catch {
+                await customStore.discard(lease)
+                let finalError = SFTPDragProvider.normalizedCancellationError(error)
+                completionError = finalError
+                throw finalError
+            }
+        }
+
+        await fulfillment(of: [started], timeout: 2.0)
+        let transfer = try XCTUnwrap(browser.transfers.first)
+        XCTAssertEqual(transfer.label, "扫描 scan_cancel_folder…")
+
+        // Cancel during scanning
+        browser.cancelTransfer(transfer.id)
+
+        do {
+            _ = try await dragTask.value
+            XCTFail("Drag task should throw error")
+        } catch {
+            // Expected
+        }
+
+        // 1. Error passed to completion must be CocoaError.userCancelled
+        XCTAssertTrue(completionError is CocoaError)
+        XCTAssertEqual((completionError as? CocoaError)?.code, .userCancelled)
+
+        // 2. Staging root was removed
+        XCTAssertFalse(FileManager.default.fileExists(atPath: lease.rootURL.path))
+    }
 }

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -886,4 +886,18 @@ final class SFTPBrowserTests: XCTestCase {
         }
         XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
     }
+
+    func testSFTPDragRetentionPolicyCalculations() {
+        XCTAssertEqual(SFTPDragRetentionPolicy.retentionInterval(payloadBytes: nil), 1800)
+        XCTAssertEqual(SFTPDragRetentionPolicy.retentionInterval(payloadBytes: 0), 1800)
+
+        let hundredMiB: UInt64 = 100 * 1024 * 1024
+        XCTAssertEqual(SFTPDragRetentionPolicy.retentionInterval(payloadBytes: hundredMiB), 1800)
+
+        let tenGiB: UInt64 = 10 * 1024 * 1024 * 1024
+        XCTAssertEqual(SFTPDragRetentionPolicy.retentionInterval(payloadBytes: tenGiB), 5120)
+
+        let hundredGiB: UInt64 = 100 * 1024 * 1024 * 1024
+        XCTAssertEqual(SFTPDragRetentionPolicy.retentionInterval(payloadBytes: hundredGiB), 51200)
+    }
 }

--- a/BerthTests/SFTPDragStagingStoreTests.swift
+++ b/BerthTests/SFTPDragStagingStoreTests.swift
@@ -15,7 +15,9 @@ final class SFTPDragStagingStoreTests: XCTestCase {
             baseDirectory: tempDirectoryURL,
             deliveredGracePeriod: 1800,  // 30 mins
             interruptedGracePeriod: 3600, // 1 hour
-            absoluteCeiling: 86400       // 24 hours
+            absoluteCeiling: 86400,      // 24 hours
+            legacyGracePeriod: 86400,    // 24 hours
+            minimumSweepInterval: 60     // 60 seconds
         )
     }
 
@@ -43,6 +45,15 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         XCTAssertNil(metadata.deliveredAt)
     }
 
+    func testCreateWithMaliciousNameThrowsAndDoesNotEscape() async throws {
+        do {
+            _ = try await store.create(named: "../../etc/passwd", isDirectory: false)
+            XCTFail("Should not allow path traversal in staging name")
+        } catch {
+            // Expected
+        }
+    }
+
     func testDiscardImmediatelyRemovesStagingRoot() async throws {
         let lease = try await store.create(named: "test_folder", isDirectory: true)
         XCTAssertTrue(FileManager.default.fileExists(atPath: lease.rootURL.path))
@@ -60,7 +71,7 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         try "hello staging".write(to: lease.payloadURL, atomically: true, encoding: .utf8)
 
         let deliveryTime = Date()
-        await store.markDelivered(lease, now: deliveryTime)
+        await store.markDelivered(lease, payloadBytes: 13, now: deliveryTime)
 
         // Payload must still exist after delivery
         XCTAssertTrue(FileManager.default.fileExists(atPath: lease.payloadURL.path))
@@ -71,6 +82,7 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         decoder.dateDecodingStrategy = .iso8601
         let metadata = try decoder.decode(StagingMarkerMetadata.self, from: data)
         XCTAssertNotNil(metadata.deliveredAt)
+        XCTAssertEqual(metadata.payloadBytes, 13)
     }
 
     func testActiveLeaseIsNeverSweptEvenIfOld() async throws {
@@ -86,7 +98,7 @@ final class SFTPDragStagingStoreTests: XCTestCase {
     func testDeliveredLeaseRetainedWithinGracePeriod() async throws {
         let t0 = Date()
         let lease = try await store.create(named: "delivered_recent.bin", isDirectory: false, now: t0)
-        await store.markDelivered(lease, now: t0)
+        await store.markDelivered(lease, payloadBytes: 1024, now: t0)
 
         // 10 minutes later (well within 30 min grace period)
         let sweepResult = try await store.sweepStale(now: t0.addingTimeInterval(600))
@@ -100,7 +112,7 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         let payloadData = Data(repeating: 0x41, count: 4096)
         try payloadData.write(to: lease.payloadURL)
 
-        await store.markDelivered(lease, now: t0)
+        await store.markDelivered(lease, payloadBytes: 4096, now: t0)
 
         // 35 minutes later (exceeds 30 min grace period)
         let sweepTime = t0.addingTimeInterval(2100)
@@ -111,7 +123,12 @@ final class SFTPDragStagingStoreTests: XCTestCase {
     }
 
     func testCrashInterruptedLeaseFromDeadPIDIsSwept() async throws {
-        // Simulate a lease created by a process that crashed/died (pid 999999)
+        // Lease created by a dead process (mocked via ESRCH in custom checker)
+        let customStore = SFTPDragStagingStore(
+            baseDirectory: tempDirectoryURL,
+            processLivenessChecker: { _ in false } // simulate dead process
+        )
+
         let deadLeaseID = UUID()
         let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(deadLeaseID.uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
@@ -119,7 +136,7 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         let metadata = StagingMarkerMetadata(
             schemaVersion: 1,
             id: deadLeaseID,
-            pid: 999999, // Dead PID
+            pid: 999999,
             createdAt: Date().addingTimeInterval(-120),
             deliveredAt: nil,
             payloadName: "crashed_payload",
@@ -131,27 +148,122 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         let data = try encoder.encode(metadata)
         try data.write(to: markerURL)
 
-        let sweepResult = try await store.sweepStale(now: Date())
+        let sweepResult = try await customStore.sweepStale(now: Date())
         XCTAssertEqual(sweepResult.reclaimedCount, 1)
         XCTAssertFalse(FileManager.default.fileExists(atPath: rootURL.path))
     }
 
-    func testDirectoryWithoutMarkerIsNeverSwept() async throws {
-        // Even if directory matches prefix Berth-Drag-*, without valid marker it must NOT be touched!
-        let fakeUUID = UUID()
-        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(fakeUUID.uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
-        let payloadURL = rootURL.appendingPathComponent("user_important.txt")
-        try "critical data".write(to: payloadURL, atomically: true, encoding: .utf8)
+    func testInterruptedLeaseFromAlivePIDIsProtected() async throws {
+        // Lease created by a process that is STILL ALIVE (mocked via true in custom checker)
+        let customStore = SFTPDragStagingStore(
+            baseDirectory: tempDirectoryURL,
+            interruptedGracePeriod: 3600,
+            processLivenessChecker: { _ in true } // simulate live process
+        )
 
-        let sweepResult = try await store.sweepStale(now: Date().addingTimeInterval(100000))
+        let liveLeaseID = UUID()
+        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(liveLeaseID.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+
+        let metadata = StagingMarkerMetadata(
+            schemaVersion: 1,
+            id: liveLeaseID,
+            pid: 888888,
+            createdAt: Date().addingTimeInterval(-120), // 2 mins old, well within 1 hour
+            deliveredAt: nil,
+            payloadName: "active_other_process",
+            isDirectory: true
+        )
+        let markerURL = rootURL.appendingPathComponent(SFTPDragStagingStore.markerFilename)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(metadata)
+        try data.write(to: markerURL)
+
+        let sweepResult = try await customStore.sweepStale(now: Date())
         XCTAssertEqual(sweepResult.reclaimedCount, 0)
         XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: payloadURL.path))
+    }
+
+    func testProcessLivenessCheckerBehavior() {
+        // Current process is alive
+        let currentPID = ProcessInfo.processInfo.processIdentifier
+        XCTAssertTrue(SFTPDragStagingStore.defaultProcessLivenessChecker(currentPID))
+
+        // Non-existent PID
+        XCTAssertFalse(SFTPDragStagingStore.defaultProcessLivenessChecker(9999999))
+
+        // Invalid PID
+        XCTAssertFalse(SFTPDragStagingStore.defaultProcessLivenessChecker(-1))
+        XCTAssertFalse(SFTPDragStagingStore.defaultProcessLivenessChecker(0))
+    }
+
+    // MARK: - Legacy markerless staging tests (P1-1)
+
+    func testLegacyMarkerlessOldDirectoryIsSwept() async throws {
+        let legacyUUID = UUID()
+        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(legacyUUID.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let payloadURL = rootURL.appendingPathComponent("legacy_file.txt")
+        try "legacy data".write(to: payloadURL, atomically: true, encoding: .utf8)
+
+        // Set modification date to 48 hours ago
+        let oldDate = Date().addingTimeInterval(-48 * 3600)
+        try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: rootURL.path)
+
+        let sweepResult = try await store.sweepStale(now: Date())
+        XCTAssertEqual(sweepResult.reclaimedLegacyCount, 1)
+        XCTAssertEqual(sweepResult.reclaimedCount, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: rootURL.path))
+    }
+
+    func testLegacyMarkerlessRecentDirectoryIsNOTSwept() async throws {
+        let legacyUUID = UUID()
+        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(legacyUUID.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let payloadURL = rootURL.appendingPathComponent("recent_file.txt")
+        try "recent data".write(to: payloadURL, atomically: true, encoding: .utf8)
+
+        // Set modification date to only 1 hour ago (legacy TTL is 24h)
+        let recentDate = Date().addingTimeInterval(-3600)
+        try FileManager.default.setAttributes([.modificationDate: recentDate], ofItemAtPath: rootURL.path)
+
+        let sweepResult = try await store.sweepStale(now: Date())
+        XCTAssertEqual(sweepResult.reclaimedLegacyCount, 0)
+        XCTAssertEqual(sweepResult.reclaimedCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
+    }
+
+    func testLegacyMarkerlessInvalidUUIDNameIsNOTSwept() async throws {
+        // Name has prefix but does NOT end in a valid UUID
+        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)foo", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let payloadURL = rootURL.appendingPathComponent("important.txt")
+        try "do not touch".write(to: payloadURL, atomically: true, encoding: .utf8)
+
+        let oldDate = Date().addingTimeInterval(-100 * 3600)
+        try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: rootURL.path)
+
+        let sweepResult = try await store.sweepStale(now: Date())
+        XCTAssertEqual(sweepResult.reclaimedCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
+    }
+
+    func testUnrelatedDirectoryIsNOTSwept() async throws {
+        let rootURL = tempDirectoryURL.appendingPathComponent("SomeOtherAppDirectory", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let payloadURL = rootURL.appendingPathComponent("doc.txt")
+        try "user data".write(to: payloadURL, atomically: true, encoding: .utf8)
+
+        let oldDate = Date().addingTimeInterval(-100 * 3600)
+        try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: rootURL.path)
+
+        let sweepResult = try await store.sweepStale(now: Date())
+        XCTAssertEqual(sweepResult.reclaimedCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
     }
 
     func testSymlinkOutsideBaseIsNeverSweptOrFollowed() async throws {
-        // Create an outside target directory
         let outsideDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("Berth-OutsideTarget-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: outsideDir, withIntermediateDirectories: true)
@@ -167,5 +279,25 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         let sweepResult = try await store.sweepStale(now: Date().addingTimeInterval(100000))
         XCTAssertEqual(sweepResult.reclaimedCount, 0)
         XCTAssertTrue(FileManager.default.fileExists(atPath: outsideFile.path))
+    }
+
+    // MARK: - Sweep Throttling Tests (P3-2)
+
+    func testSweepThrottlingSkipsExecutionWhenIntervalNotMet() async throws {
+        let now = Date()
+        // First sweep records lastSweepDate
+        _ = try await store.sweepStale(now: now, force: true)
+
+        // Create a stale lease
+        let lease = try await store.create(named: "throttled.bin", isDirectory: false, now: now.addingTimeInterval(-7200))
+        await store.markDelivered(lease, now: now.addingTimeInterval(-7200))
+
+        // Sweep 10 seconds later with force: false (minimumSweepInterval is 60s)
+        let throttledResult = try await store.sweepStale(now: now.addingTimeInterval(10), force: false)
+        XCTAssertEqual(throttledResult.examinedCount, 0, "Throttled sweep must skip examination")
+
+        // Sweep 70 seconds later with force: false (exceeds interval)
+        let activeResult = try await store.sweepStale(now: now.addingTimeInterval(70), force: false)
+        XCTAssertEqual(activeResult.reclaimedCount, 1, "Sweep should execute once interval has elapsed")
     }
 }

--- a/BerthTests/SFTPDragStagingStoreTests.swift
+++ b/BerthTests/SFTPDragStagingStoreTests.swift
@@ -250,9 +250,10 @@ final class SFTPDragStagingStoreTests: XCTestCase {
     }
 
     func testCrashInterruptedLeaseFromDeadPIDIsSwept() async throws {
-        // Lease created by a dead process (mocked via ESRCH in custom checker)
+        // Lease created by a dead process (mocked via false in custom checker)
         let customStore = SFTPDragStagingStore(
             baseDirectory: tempDirectoryURL,
+            interruptedGracePeriod: 3600,
             processLivenessChecker: { _ in false } // simulate dead process
         )
 
@@ -260,11 +261,12 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(deadLeaseID.uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
 
+        let t0 = Date()
         let metadata = StagingMarkerMetadata(
             schemaVersion: 1,
             id: deadLeaseID,
             pid: 999999,
-            createdAt: Date().addingTimeInterval(-120),
+            createdAt: t0.addingTimeInterval(-7200),
             deliveredAt: nil,
             payloadName: "crashed_payload",
             isDirectory: true
@@ -275,9 +277,71 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         let data = try encoder.encode(metadata)
         try data.write(to: markerURL)
 
-        let sweepResult = try await customStore.sweepStale(now: Date())
-        XCTAssertEqual(sweepResult.reclaimedCount, 1)
+        // First sweep: dead owner detected -> writes orphanedAt, MUST NOT delete immediately
+        let firstSweep = try await customStore.sweepStale(now: t0)
+        XCTAssertEqual(firstSweep.reclaimedCount, 0, "First sweep upon discovering dead owner must record orphanedAt and keep staging")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
+
+        // Read back marker to verify orphanedAt was recorded
+        let updatedData = try Data(contentsOf: markerURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let updatedMetadata = try decoder.decode(StagingMarkerMetadata.self, from: updatedData)
+        XCTAssertNotNil(updatedMetadata.orphanedAt)
+
+        // 30 mins after orphanedAt (grace is 60m): still kept
+        let intermediateSweep = try await customStore.sweepStale(now: t0.addingTimeInterval(1800))
+        XCTAssertEqual(intermediateSweep.reclaimedCount, 0, "Within grace period after dead owner detection, staging must be kept")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
+
+        // 65 mins after orphanedAt: grace passed -> swept
+        let expiredSweep = try await customStore.sweepStale(now: t0.addingTimeInterval(3900))
+        XCTAssertEqual(expiredSweep.reclaimedCount, 1, "After grace period from orphanedAt, dead lease must be reclaimed")
         XCTAssertFalse(FileManager.default.fileExists(atPath: rootURL.path))
+    }
+
+    func testForeignOwnerAliveKeptAt30Min2HoursAnd48Hours() async throws {
+        let customStore = SFTPDragStagingStore(
+            baseDirectory: tempDirectoryURL,
+            interruptedGracePeriod: 3600,   // 1 hour
+            absoluteCeiling: 86400,         // 24 hours
+            processLivenessChecker: { _ in true } // foreign owner process is STILL ALIVE
+        )
+
+        let leaseID = UUID()
+        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(leaseID.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+
+        let t0 = Date()
+        let metadata = StagingMarkerMetadata(
+            schemaVersion: 1,
+            id: leaseID,
+            pid: 777777,
+            createdAt: t0,
+            deliveredAt: nil,
+            payloadName: "large_active_download",
+            isDirectory: true
+        )
+        let markerURL = rootURL.appendingPathComponent(SFTPDragStagingStore.markerFilename)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(metadata)
+        try data.write(to: markerURL)
+
+        // 30 mins later: owner alive -> KEEP
+        let sweep30m = try await customStore.sweepStale(now: t0.addingTimeInterval(1800))
+        XCTAssertEqual(sweep30m.reclaimedCount, 0, "Foreign active lease with live owner must be kept at 30 min")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
+
+        // 2 hours later (exceeds interruptedGracePeriod 1h): owner alive -> KEEP
+        let sweep2h = try await customStore.sweepStale(now: t0.addingTimeInterval(7200))
+        XCTAssertEqual(sweep2h.reclaimedCount, 0, "Foreign active lease with live owner must be kept at 2 hours")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
+
+        // 48 hours later (exceeds absoluteCeiling 24h): owner alive -> KEEP
+        let sweep48h = try await customStore.sweepStale(now: t0.addingTimeInterval(48 * 3600))
+        XCTAssertEqual(sweep48h.reclaimedCount, 0, "Foreign active lease with live owner must be kept even at 48 hours")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
     }
 
     func testInterruptedLeaseFromAlivePIDIsProtected() async throws {

--- a/BerthTests/SFTPDragStagingStoreTests.swift
+++ b/BerthTests/SFTPDragStagingStoreTests.swift
@@ -13,9 +13,7 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         try FileManager.default.createDirectory(at: tempDirectoryURL, withIntermediateDirectories: true)
         store = SFTPDragStagingStore(
             baseDirectory: tempDirectoryURL,
-            deliveredGracePeriod: 1800,  // 30 mins
             interruptedGracePeriod: 3600, // 1 hour
-            absoluteCeiling: 86400,      // 24 hours
             legacyGracePeriod: 86400,    // 24 hours
             minimumSweepInterval: 60     // 60 seconds
         )
@@ -52,6 +50,21 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         } catch {
             // Expected
         }
+    }
+
+    func testCreateRemovesRootWhenInitialMarkerWriteFails() async throws {
+        let failingStore = SFTPDragStagingStore(
+            baseDirectory: tempDirectoryURL,
+            markerWriter: { _, _ in throw CocoaError(.fileWriteNoPermission) }
+        )
+
+        do {
+            _ = try await failingStore.create(named: "marker-failure.txt", isDirectory: false)
+            XCTFail("create must throw when the initial marker write fails")
+        } catch {
+            // Expected.
+        }
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: tempDirectoryURL.path), [])
     }
 
     func testDiscardImmediatelyRemovesStagingRoot() async throws {
@@ -304,7 +317,6 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         let customStore = SFTPDragStagingStore(
             baseDirectory: tempDirectoryURL,
             interruptedGracePeriod: 3600,   // 1 hour
-            absoluteCeiling: 86400,         // 24 hours
             processLivenessChecker: { _ in true } // foreign owner process is STILL ALIVE
         )
 
@@ -338,7 +350,7 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         XCTAssertEqual(sweep2h.reclaimedCount, 0, "Foreign active lease with live owner must be kept at 2 hours")
         XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
 
-        // 48 hours later (exceeds absoluteCeiling 24h): owner alive -> KEEP
+        // 48 hours later: owner alive -> KEEP
         let sweep48h = try await customStore.sweepStale(now: t0.addingTimeInterval(48 * 3600))
         XCTAssertEqual(sweep48h.reclaimedCount, 0, "Foreign active lease with live owner must be kept even at 48 hours")
         XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))

--- a/BerthTests/SFTPDragStagingStoreTests.swift
+++ b/BerthTests/SFTPDragStagingStoreTests.swift
@@ -71,7 +71,7 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         try "hello staging".write(to: lease.payloadURL, atomically: true, encoding: .utf8)
 
         let deliveryTime = Date()
-        await store.markDelivered(lease, payloadBytes: 13, now: deliveryTime)
+        try await store.markDelivered(lease, payloadBytes: 13, now: deliveryTime)
 
         // Payload must still exist after delivery
         XCTAssertTrue(FileManager.default.fileExists(atPath: lease.payloadURL.path))
@@ -83,6 +83,35 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         let metadata = try decoder.decode(StagingMarkerMetadata.self, from: data)
         XCTAssertNotNil(metadata.deliveredAt)
         XCTAssertEqual(metadata.payloadBytes, 13)
+    }
+
+    func testMarkDeliveredAtomicWriteFailureKeepsActive() async throws {
+        final class MockWriter: @unchecked Sendable {
+            var fail = false
+        }
+        let mock = MockWriter()
+        let failingStore = SFTPDragStagingStore(
+            baseDirectory: tempDirectoryURL,
+            markerWriter: { data, url in
+                if mock.fail {
+                    throw CocoaError(.fileWriteNoPermission)
+                }
+                try data.write(to: url, options: .atomic)
+            }
+        )
+        let lease = try await failingStore.create(named: "fail_marker.txt", isDirectory: false)
+        mock.fail = true
+
+        do {
+            try await failingStore.markDelivered(lease, payloadBytes: 1024)
+            XCTFail("markDelivered must throw when marker write fails")
+        } catch {
+            // Expected
+        }
+
+        // Active lease must NOT be swept while failing/active
+        let sweepResult = try await failingStore.sweepStale(now: Date().addingTimeInterval(7200))
+        XCTAssertEqual(sweepResult.reclaimedCount, 0, "Active lease must remain protected")
     }
 
     func testActiveLeaseIsNeverSweptEvenIfOld() async throws {
@@ -98,7 +127,7 @@ final class SFTPDragStagingStoreTests: XCTestCase {
     func testDeliveredLeaseRetainedWithinGracePeriod() async throws {
         let t0 = Date()
         let lease = try await store.create(named: "delivered_recent.bin", isDirectory: false, now: t0)
-        await store.markDelivered(lease, payloadBytes: 1024, now: t0)
+        try await store.markDelivered(lease, payloadBytes: 1024, now: t0)
 
         // 10 minutes later (well within 30 min grace period)
         let sweepResult = try await store.sweepStale(now: t0.addingTimeInterval(600))
@@ -112,7 +141,7 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         let payloadData = Data(repeating: 0x41, count: 4096)
         try payloadData.write(to: lease.payloadURL)
 
-        await store.markDelivered(lease, payloadBytes: 4096, now: t0)
+        try await store.markDelivered(lease, payloadBytes: 4096, now: t0)
 
         // 35 minutes later (exceeds 30 min grace period)
         let sweepTime = t0.addingTimeInterval(2100)
@@ -120,6 +149,104 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         XCTAssertEqual(sweepResult.reclaimedCount, 1)
         XCTAssertGreaterThanOrEqual(sweepResult.reclaimedBytes, 4096)
         XCTAssertFalse(FileManager.default.fileExists(atPath: lease.rootURL.path))
+    }
+
+    // MARK: - Large Directory Retention Tests (P1)
+
+    func testLargeDirectoryRetentionScalesWithCopiedBytes() async throws {
+        // 100 GiB payload size
+        let hundredGiB: UInt64 = 100 * 1024 * 1024 * 1024
+        let expectedRetention = SFTPDragRetentionPolicy.retentionInterval(payloadBytes: hundredGiB)
+        // 100 GiB / 2 MiB/s = 51,200 seconds (~14.2 hours)
+        XCTAssertEqual(expectedRetention, 51200, accuracy: 1.0)
+
+        let t0 = Date()
+        let lease = try await store.create(named: "large_dir", isDirectory: true, now: t0)
+        try await store.markDelivered(lease, payloadBytes: hundredGiB, now: t0)
+
+        // 1 hour later: MUST NOT be swept
+        let oneHourLater = try await store.sweepStale(now: t0.addingTimeInterval(3600))
+        XCTAssertEqual(oneHourLater.reclaimedCount, 0, "100 GiB folder must not be swept after 1 hour")
+
+        // 10 hours later (36,000s): MUST NOT be swept
+        let tenHoursLater = try await store.sweepStale(now: t0.addingTimeInterval(36000))
+        XCTAssertEqual(tenHoursLater.reclaimedCount, 0, "100 GiB folder must not be swept after 10 hours")
+
+        // 15 hours later (54,000s > 51,200s): MUST be swept
+        let fifteenHoursLater = try await store.sweepStale(now: t0.addingTimeInterval(54000))
+        XCTAssertEqual(fifteenHoursLater.reclaimedCount, 1, "100 GiB folder should be swept after retention window expires")
+    }
+
+    func testActualCopiedBytesPersistedToMarker() async throws {
+        // Simulate directory with initial entry size 1 MiB but actual downloaded copiedBytes = 10 GiB
+        let tenGiB: UInt64 = 10 * 1024 * 1024 * 1024
+        let lease = try await store.create(named: "downloaded_tree", isDirectory: true)
+
+        try await store.markDelivered(lease, payloadBytes: tenGiB)
+
+        let markerURL = lease.rootURL.appendingPathComponent(SFTPDragStagingStore.markerFilename)
+        let data = try Data(contentsOf: markerURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let metadata = try decoder.decode(StagingMarkerMetadata.self, from: data)
+
+        XCTAssertEqual(metadata.payloadBytes, tenGiB, "Marker must accurately persist the actual downloaded copiedBytes")
+    }
+
+    func testDeliveredLeaseWithDeadPIDIsRetainedUntilRetentionExpires() async throws {
+        // Simulate a crash after delivery of a 100 GiB directory:
+        // DeliveredAt is recent, PID belongs to a dead process.
+        let customStore = SFTPDragStagingStore(
+            baseDirectory: tempDirectoryURL,
+            processLivenessChecker: { _ in false } // dead process
+        )
+
+        let hundredGiB: UInt64 = 100 * 1024 * 1024 * 1024
+        let leaseID = UUID()
+        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(leaseID.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+
+        let t0 = Date()
+        let metadata = StagingMarkerMetadata(
+            schemaVersion: 1,
+            id: leaseID,
+            pid: 999999, // dead PID
+            createdAt: t0,
+            deliveredAt: t0,
+            payloadName: "crashed_after_delivery",
+            isDirectory: true,
+            payloadBytes: hundredGiB
+        )
+        let markerURL = rootURL.appendingPathComponent(SFTPDragStagingStore.markerFilename)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(metadata)
+        try data.write(to: markerURL)
+
+        // 2 hours after crash: Finder may still be copying to slow NAS. Dead PID must NOT trigger immediate deletion!
+        let sweepResult = try await customStore.sweepStale(now: t0.addingTimeInterval(7200))
+        XCTAssertEqual(sweepResult.reclaimedCount, 0, "Delivered staging must be retained within retention window even if owner PID is dead")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
+
+        // 15 hours later: Retention expired. Must now be swept.
+        let expiredSweep = try await customStore.sweepStale(now: t0.addingTimeInterval(54000))
+        XCTAssertEqual(expiredSweep.reclaimedCount, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: rootURL.path))
+    }
+
+    func testDeliveredLargeDirectoryRetainedAcrossRestart() async throws {
+        let hundredGiB: UInt64 = 100 * 1024 * 1024 * 1024
+        let t0 = Date()
+        let lease = try await store.create(named: "restart_test_dir", isDirectory: true, now: t0)
+        try await store.markDelivered(lease, payloadBytes: hundredGiB, now: t0)
+
+        // Simulate app restart by initializing a brand new SFTPDragStagingStore instance
+        let restartedStore = SFTPDragStagingStore(baseDirectory: tempDirectoryURL)
+
+        // Sweep 2 hours after restart: should retain
+        let sweepResult = try await restartedStore.sweepStale(now: t0.addingTimeInterval(7200))
+        XCTAssertEqual(sweepResult.reclaimedCount, 0, "Restarted store must recover retention from marker and retain delivered directory")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: lease.rootURL.path))
     }
 
     func testCrashInterruptedLeaseFromDeadPIDIsSwept() async throws {
@@ -290,7 +417,7 @@ final class SFTPDragStagingStoreTests: XCTestCase {
 
         // Create a stale lease
         let lease = try await store.create(named: "throttled.bin", isDirectory: false, now: now.addingTimeInterval(-7200))
-        await store.markDelivered(lease, now: now.addingTimeInterval(-7200))
+        try await store.markDelivered(lease, payloadBytes: 100, now: now.addingTimeInterval(-7200))
 
         // Sweep 10 seconds later with force: false (minimumSweepInterval is 60s)
         let throttledResult = try await store.sweepStale(now: now.addingTimeInterval(10), force: false)

--- a/BerthTests/SFTPDragStagingStoreTests.swift
+++ b/BerthTests/SFTPDragStagingStoreTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+@testable import Berth
+
+final class SFTPDragStagingStoreTests: XCTestCase {
+
+    private var tempDirectoryURL: URL!
+    private var store: SFTPDragStagingStore!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Berth-StagingStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectoryURL, withIntermediateDirectories: true)
+        store = SFTPDragStagingStore(
+            baseDirectory: tempDirectoryURL,
+            deliveredGracePeriod: 1800,  // 30 mins
+            interruptedGracePeriod: 3600, // 1 hour
+            absoluteCeiling: 86400       // 24 hours
+        )
+    }
+
+    override func tearDown() async throws {
+        if let tempDirectoryURL {
+            try? FileManager.default.removeItem(at: tempDirectoryURL)
+        }
+        try await super.tearDown()
+    }
+
+    func testCreateWritesMarkerAndTracksActiveLease() async throws {
+        let lease = try await store.create(named: "bundle.tar.gz", isDirectory: false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: lease.rootURL.path))
+        XCTAssertEqual(lease.payloadURL.lastPathComponent, "bundle.tar.gz")
+
+        let markerURL = lease.rootURL.appendingPathComponent(SFTPDragStagingStore.markerFilename)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markerURL.path))
+
+        let data = try Data(contentsOf: markerURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let metadata = try decoder.decode(StagingMarkerMetadata.self, from: data)
+        XCTAssertEqual(metadata.id, lease.id)
+        XCTAssertEqual(metadata.payloadName, "bundle.tar.gz")
+        XCTAssertNil(metadata.deliveredAt)
+    }
+
+    func testDiscardImmediatelyRemovesStagingRoot() async throws {
+        let lease = try await store.create(named: "test_folder", isDirectory: true)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: lease.rootURL.path))
+
+        await store.discard(lease)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: lease.rootURL.path))
+
+        // Idempotent: repeated discard does not throw or fail
+        await store.discard(lease)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: lease.rootURL.path))
+    }
+
+    func testMarkDeliveredUpdatesMarkerAndRetainsPayload() async throws {
+        let lease = try await store.create(named: "output.log", isDirectory: false)
+        try "hello staging".write(to: lease.payloadURL, atomically: true, encoding: .utf8)
+
+        let deliveryTime = Date()
+        await store.markDelivered(lease, now: deliveryTime)
+
+        // Payload must still exist after delivery
+        XCTAssertTrue(FileManager.default.fileExists(atPath: lease.payloadURL.path))
+
+        let markerURL = lease.rootURL.appendingPathComponent(SFTPDragStagingStore.markerFilename)
+        let data = try Data(contentsOf: markerURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let metadata = try decoder.decode(StagingMarkerMetadata.self, from: data)
+        XCTAssertNotNil(metadata.deliveredAt)
+    }
+
+    func testActiveLeaseIsNeverSweptEvenIfOld() async throws {
+        let past = Date().addingTimeInterval(-7200) // 2 hours ago
+        let lease = try await store.create(named: "active_huge.bin", isDirectory: false, now: past)
+
+        // Sweep running right now
+        let sweepResult = try await store.sweepStale(now: Date())
+        XCTAssertEqual(sweepResult.reclaimedCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: lease.rootURL.path))
+    }
+
+    func testDeliveredLeaseRetainedWithinGracePeriod() async throws {
+        let t0 = Date()
+        let lease = try await store.create(named: "delivered_recent.bin", isDirectory: false, now: t0)
+        await store.markDelivered(lease, now: t0)
+
+        // 10 minutes later (well within 30 min grace period)
+        let sweepResult = try await store.sweepStale(now: t0.addingTimeInterval(600))
+        XCTAssertEqual(sweepResult.reclaimedCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: lease.rootURL.path))
+    }
+
+    func testStaleDeliveredLeaseIsSweptAndReclaimed() async throws {
+        let t0 = Date()
+        let lease = try await store.create(named: "delivered_old.bin", isDirectory: false, now: t0)
+        let payloadData = Data(repeating: 0x41, count: 4096)
+        try payloadData.write(to: lease.payloadURL)
+
+        await store.markDelivered(lease, now: t0)
+
+        // 35 minutes later (exceeds 30 min grace period)
+        let sweepTime = t0.addingTimeInterval(2100)
+        let sweepResult = try await store.sweepStale(now: sweepTime)
+        XCTAssertEqual(sweepResult.reclaimedCount, 1)
+        XCTAssertGreaterThanOrEqual(sweepResult.reclaimedBytes, 4096)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: lease.rootURL.path))
+    }
+
+    func testCrashInterruptedLeaseFromDeadPIDIsSwept() async throws {
+        // Simulate a lease created by a process that crashed/died (pid 999999)
+        let deadLeaseID = UUID()
+        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(deadLeaseID.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+
+        let metadata = StagingMarkerMetadata(
+            schemaVersion: 1,
+            id: deadLeaseID,
+            pid: 999999, // Dead PID
+            createdAt: Date().addingTimeInterval(-120),
+            deliveredAt: nil,
+            payloadName: "crashed_payload",
+            isDirectory: true
+        )
+        let markerURL = rootURL.appendingPathComponent(SFTPDragStagingStore.markerFilename)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(metadata)
+        try data.write(to: markerURL)
+
+        let sweepResult = try await store.sweepStale(now: Date())
+        XCTAssertEqual(sweepResult.reclaimedCount, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: rootURL.path))
+    }
+
+    func testDirectoryWithoutMarkerIsNeverSwept() async throws {
+        // Even if directory matches prefix Berth-Drag-*, without valid marker it must NOT be touched!
+        let fakeUUID = UUID()
+        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(fakeUUID.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let payloadURL = rootURL.appendingPathComponent("user_important.txt")
+        try "critical data".write(to: payloadURL, atomically: true, encoding: .utf8)
+
+        let sweepResult = try await store.sweepStale(now: Date().addingTimeInterval(100000))
+        XCTAssertEqual(sweepResult.reclaimedCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: payloadURL.path))
+    }
+
+    func testSymlinkOutsideBaseIsNeverSweptOrFollowed() async throws {
+        // Create an outside target directory
+        let outsideDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Berth-OutsideTarget-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: outsideDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outsideDir) }
+
+        let outsideFile = outsideDir.appendingPathComponent("keep_me.txt")
+        try "keep me".write(to: outsideFile, atomically: true, encoding: .utf8)
+
+        // Create symlink inside base pointing to outside
+        let symlinkRoot = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(UUID().uuidString)")
+        try FileManager.default.createSymbolicLink(at: symlinkRoot, withDestinationURL: outsideDir)
+
+        let sweepResult = try await store.sweepStale(now: Date().addingTimeInterval(100000))
+        XCTAssertEqual(sweepResult.reclaimedCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outsideFile.path))
+    }
+}

--- a/BerthTests/SFTPDragStagingStoreTests.swift
+++ b/BerthTests/SFTPDragStagingStoreTests.swift
@@ -14,7 +14,6 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         store = SFTPDragStagingStore(
             baseDirectory: tempDirectoryURL,
             interruptedGracePeriod: 3600, // 1 hour
-            legacyGracePeriod: 86400,    // 24 hours
             minimumSweepInterval: 60     // 60 seconds
         )
     }
@@ -38,9 +37,32 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let metadata = try decoder.decode(StagingMarkerMetadata.self, from: data)
+        XCTAssertEqual(metadata.schemaVersion, 2)
         XCTAssertEqual(metadata.id, lease.id)
+        XCTAssertEqual(metadata.ownerNonce, lease.ownerNonce)
+        XCTAssertNotNil(metadata.heartbeatAt)
         XCTAssertEqual(metadata.payloadName, "bundle.tar.gz")
         XCTAssertNil(metadata.deliveredAt)
+    }
+
+    func testActiveLeaseRefreshesHeartbeat() async throws {
+        let t0 = Date().addingTimeInterval(-3600)
+        let heartbeatStore = SFTPDragStagingStore(
+            baseDirectory: tempDirectoryURL,
+            heartbeatInterval: 0.02,
+            heartbeatTimeout: 1
+        )
+        let lease = try await heartbeatStore.create(named: "heartbeat.bin", isDirectory: false, now: t0)
+        try await Task.sleep(for: .milliseconds(80))
+
+        let markerURL = lease.rootURL.appendingPathComponent(SFTPDragStagingStore.markerFilename)
+        let data = try Data(contentsOf: markerURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let metadata = try decoder.decode(StagingMarkerMetadata.self, from: data)
+        XCTAssertGreaterThan(try XCTUnwrap(metadata.heartbeatAt), t0)
+
+        await heartbeatStore.discard(lease)
     }
 
     func testCreateWithMaliciousNameThrowsAndDoesNotEscape() async throws {
@@ -388,6 +410,70 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
     }
 
+    func testSchemaV2FreshForeignHeartbeatProtectsLease() async throws {
+        let storeNonce = UUID()
+        let customStore = SFTPDragStagingStore(
+            baseDirectory: tempDirectoryURL,
+            interruptedGracePeriod: 3600,
+            heartbeatTimeout: 300,
+            ownerNonce: storeNonce,
+            processLivenessChecker: { _ in true }
+        )
+        let leaseID = UUID()
+        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(leaseID.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let now = Date()
+        let metadata = StagingMarkerMetadata(
+            schemaVersion: 2,
+            id: leaseID,
+            pid: 777777,
+            ownerNonce: UUID(),
+            createdAt: now.addingTimeInterval(-7200),
+            heartbeatAt: now.addingTimeInterval(-60),
+            payloadName: "foreign-active.bin",
+            isDirectory: false
+        )
+        try writeMarker(metadata, under: rootURL)
+
+        let result = try await customStore.sweepStale(now: now)
+
+        XCTAssertEqual(result.reclaimedCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
+    }
+
+    func testSchemaV2StaleHeartbeatWithReusedPIDUsesOrphanGrace() async throws {
+        let now = Date()
+        let customStore = SFTPDragStagingStore(
+            baseDirectory: tempDirectoryURL,
+            interruptedGracePeriod: 3600,
+            heartbeatTimeout: 300,
+            ownerNonce: UUID(),
+            processLivenessChecker: { _ in true }
+        )
+        let leaseID = UUID()
+        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(leaseID.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let metadata = StagingMarkerMetadata(
+            schemaVersion: 2,
+            id: leaseID,
+            pid: ProcessInfo.processInfo.processIdentifier,
+            ownerNonce: UUID(),
+            createdAt: now.addingTimeInterval(-7200),
+            heartbeatAt: now.addingTimeInterval(-7200),
+            payloadName: "pid-reused.bin",
+            isDirectory: false
+        )
+        try writeMarker(metadata, under: rootURL)
+
+        let firstSweep = try await customStore.sweepStale(now: now)
+        XCTAssertEqual(firstSweep.reclaimedCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
+
+        let secondSweep = try await customStore.sweepStale(now: now.addingTimeInterval(3601))
+        XCTAssertEqual(secondSweep.reclaimedCount, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: rootURL.path))
+    }
+
     func testProcessLivenessCheckerBehavior() {
         // Current process is alive
         let currentPID = ProcessInfo.processInfo.processIdentifier
@@ -401,38 +487,20 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         XCTAssertFalse(SFTPDragStagingStore.defaultProcessLivenessChecker(0))
     }
 
-    // MARK: - Legacy markerless staging tests (P1-1)
+    // MARK: - Marker ownership tests
 
-    func testLegacyMarkerlessOldDirectoryIsSwept() async throws {
-        let legacyUUID = UUID()
-        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(legacyUUID.uuidString)", isDirectory: true)
+    func testMarkerlessUUIDDirectoryIsNeverSwept() async throws {
+        let unknownUUID = UUID()
+        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(unknownUUID.uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
-        let payloadURL = rootURL.appendingPathComponent("legacy_file.txt")
-        try "legacy data".write(to: payloadURL, atomically: true, encoding: .utf8)
+        let payloadURL = rootURL.appendingPathComponent("unowned.txt")
+        try "must remain".write(to: payloadURL, atomically: true, encoding: .utf8)
 
         // Set modification date to 48 hours ago
         let oldDate = Date().addingTimeInterval(-48 * 3600)
         try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: rootURL.path)
 
         let sweepResult = try await store.sweepStale(now: Date())
-        XCTAssertEqual(sweepResult.reclaimedLegacyCount, 1)
-        XCTAssertEqual(sweepResult.reclaimedCount, 1)
-        XCTAssertFalse(FileManager.default.fileExists(atPath: rootURL.path))
-    }
-
-    func testLegacyMarkerlessRecentDirectoryIsNOTSwept() async throws {
-        let legacyUUID = UUID()
-        let rootURL = tempDirectoryURL.appendingPathComponent("\(SFTPDragStagingStore.prefix)\(legacyUUID.uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
-        let payloadURL = rootURL.appendingPathComponent("recent_file.txt")
-        try "recent data".write(to: payloadURL, atomically: true, encoding: .utf8)
-
-        // Set modification date to only 1 hour ago (legacy TTL is 24h)
-        let recentDate = Date().addingTimeInterval(-3600)
-        try FileManager.default.setAttributes([.modificationDate: recentDate], ofItemAtPath: rootURL.path)
-
-        let sweepResult = try await store.sweepStale(now: Date())
-        XCTAssertEqual(sweepResult.reclaimedLegacyCount, 0)
         XCTAssertEqual(sweepResult.reclaimedCount, 0)
         XCTAssertTrue(FileManager.default.fileExists(atPath: rootURL.path))
     }
@@ -502,5 +570,14 @@ final class SFTPDragStagingStoreTests: XCTestCase {
         // Sweep 70 seconds later with force: false (exceeds interval)
         let activeResult = try await store.sweepStale(now: now.addingTimeInterval(70), force: false)
         XCTAssertEqual(activeResult.reclaimedCount, 1, "Sweep should execute once interval has elapsed")
+    }
+
+    private func writeMarker(_ metadata: StagingMarkerMetadata, under rootURL: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(metadata).write(
+            to: rootURL.appendingPathComponent(SFTPDragStagingStore.markerFilename),
+            options: .atomic
+        )
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -102,9 +102,12 @@ targets:
       - path: Berth/Core/SSH/SOCKS5.swift
       - path: Berth/Core/SSH/SFTPBrowser.swift
       - path: Berth/Core/SSH/SFTPDownloadEngine.swift
+      - path: Berth/Core/SSH/SFTPDragRetentionPolicy.swift
+      - path: Berth/Core/SSH/SFTPDragStagingStore.swift
       - path: Berth/Core/SSH/SFTPTransferConfiguration.swift
       - path: Berth/Core/SSH/ServerInfo.swift
       - path: Berth/Core/Services/DebugLog.swift
+      - path: Berth/Core/Services/LogSanitizer.swift
       - path: Berth/Core/Services/KeyStore.swift
       - path: Berth/Core/Services/HostReachability.swift
       - path: Berth/Core/Terminal/TerminalTheme.swift


### PR DESCRIPTION
## 概述

完善 SFTP 面板向 Finder 拖出文件或目录时的下载、取消与临时文件回收流程。下载使用独立 staging 目录，避免 Finder 尚未复制完成时源文件被提前删除，同时保证失败、取消和进程异常后的数据能够安全清理。

## 主要变更

- 为 Finder 拖拽下载建立独立的 `Berth-Drag-<UUID>` staging lease，并用持久化 marker 记录所有权与交付状态。
- 支持从 Berth 传输列表和 Finder `Progress` 取消下载，取消会向 pipeline 传播并立即清理未交付的 staging 数据。
- 交付后根据实际下载字节数计算保留窗口：最低 30 分钟，并按 2 MiB/s 的保守消费速度延长大型文件或目录的保留时间。
- 在应用启动、新建拖拽等时机扫描遗留数据；使用 PID、owner nonce 和 heartbeat 区分活跃任务、PID 重用及崩溃残留。
- 无 marker、marker 不可验证、路径越界或涉及符号链接的目录一律不自动删除。
- 统一路径组件校验、取消错误归一化及日志文件名清理，避免路径穿越与控制字符污染日志。
- 为目录扫描、取消传播、多任务独立取消、跨进程 lease、heartbeat、保留窗口和安全回收补充测试。

## 生命周期行为

- 下载失败或取消：立即删除该任务的 staging root。
- 成功交付 Finder：保留到估算的消费窗口结束后再回收。
- 应用崩溃或进程失联：首次发现仅标记 orphan，经过额外宽限期后才回收。
- 仍有活跃 heartbeat 的其他 Berth 进程：不会被当前进程回收。

## 验证

- `xcodegen generate`
- macOS 完整测试套件中，除需要签名 Keychain entitlement 的既有 `KeychainStoreTests` 外，262/262 个 XCTest 通过。
- 额外 1 个 Swift Testing 测试通过。
- 无签名本机运行 `KeychainStoreTests` 会返回 `-34018`，与本 PR 的 SFTP 修改无关。
- 未进行 iOS 验证。