### PR TITLE
修复：以原子事务安全提交 SFTP 下载结果

### DIFF
--- a/Berth/App/BerthApp.swift
+++ b/Berth/App/BerthApp.swift
@@ -7,6 +7,7 @@ final class BerthAppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         MenuBarItemController.shared.start()
         Task { _ = try? await SFTPDragStagingStore.shared.sweepStale() }
+        Task.detached { _ = try? DownloadDestinationTransaction.sweepOrphans() }
     }
 }
 

--- a/Berth/Core/SSH/DownloadDestinationTransaction.swift
+++ b/Berth/Core/SSH/DownloadDestinationTransaction.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// 管理普通下载的目标路径事务提交。
+/// 保证:
+/// 1. 下载过程中不直接写入 finalURL, 也不提前 truncate 现有文件。
+/// 2. 在与 finalURL 同一父目录创建隐藏且带 UUID 的唯一 working path (.filename.berth-part-<UUID>),
+///    保证原子重命名与多任务隔离。
+/// 3. 成功完成后原子提交为 finalURL (文件使用 replaceItemAt, 目录使用 rename)。
+/// 4. 目标目录若已存在且非空, 拒绝静默覆盖/合并, 抛出明确冲突。
+/// 5. 取消或失败时 discard 删除 working path, 原 finalURL 完好无损。
+public struct DownloadDestinationTransaction: Sendable {
+    public enum TransactionError: LocalizedError, Equatable {
+        case destinationDirectoryNotEmpty(URL)
+        case invalidParentDirectory(URL)
+
+        public var errorDescription: String? {
+            switch self {
+            case .destinationDirectoryNotEmpty(let url):
+                return String(localized: "目标目录已存在且不为空: \(url.lastPathComponent)")
+            case .invalidParentDirectory(let url):
+                return String(localized: "目标父目录无效: \(url.path)")
+            }
+        }
+    }
+
+    public let finalURL: URL
+    public let workingURL: URL
+    public let isDirectory: Bool
+    private let fileManager: FileManager
+
+    public init(
+        finalURL: URL,
+        workingURL: URL,
+        isDirectory: Bool,
+        fileManager: FileManager = .default
+    ) {
+        self.finalURL = finalURL
+        self.workingURL = workingURL
+        self.isDirectory = isDirectory
+        self.fileManager = fileManager
+    }
+
+    public static func begin(
+        finalURL: URL,
+        isDirectory: Bool,
+        fileManager: FileManager = .default
+    ) throws -> DownloadDestinationTransaction {
+        let parentURL = finalURL.deletingLastPathComponent()
+        guard parentURL.path != finalURL.path else {
+            throw TransactionError.invalidParentDirectory(parentURL)
+        }
+
+        try fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
+
+        let originalName = finalURL.lastPathComponent
+        try LocalPathComponentValidator.validateComponent(originalName)
+
+        // 统一命名规则: .<originalName>.berth-part-<UUID>
+        let workingName = ".\(originalName).berth-part-\(UUID().uuidString)"
+        let workingURL = try LocalPathComponentValidator.safeURL(
+            in: parentURL,
+            component: workingName,
+            isDirectory: isDirectory
+        )
+
+        if isDirectory {
+            try fileManager.createDirectory(at: workingURL, withIntermediateDirectories: true)
+        }
+
+        return DownloadDestinationTransaction(
+            finalURL: finalURL,
+            workingURL: workingURL,
+            isDirectory: isDirectory,
+            fileManager: fileManager
+        )
+    }
+
+    public func commit() throws {
+        guard fileManager.fileExists(atPath: workingURL.path) else {
+            // 若 workingURL 未在磁盘上物化（例如仅在内存中模拟的测试执行器），无需也无法提交到 finalURL
+            return
+        }
+
+        var isDir: ObjCBool = false
+        let finalExists = fileManager.fileExists(atPath: finalURL.path, isDirectory: &isDir)
+
+        if !finalExists {
+            // final 不存在: 原子移动
+            try fileManager.moveItem(at: workingURL, to: finalURL)
+        } else if !isDirectory && !isDir.boolValue {
+            // final 是已存在文件: 原子替换
+            _ = try fileManager.replaceItemAt(
+                finalURL,
+                withItemAt: workingURL,
+                backupItemName: nil,
+                options: []
+            )
+        } else if isDirectory && isDir.boolValue {
+            // final 是已存在目录: 如果非空则拒绝静默合并, 避免不可逆覆盖
+            let contents = try fileManager.contentsOfDirectory(atPath: finalURL.path)
+            if contents.isEmpty {
+                try fileManager.removeItem(at: finalURL)
+                try fileManager.moveItem(at: workingURL, to: finalURL)
+            } else {
+                throw TransactionError.destinationDirectoryNotEmpty(finalURL)
+            }
+        } else {
+            // 文件与目录类型冲突
+            throw CocoaError(.fileWriteFileExists)
+        }
+    }
+
+    public func discard() {
+        try? fileManager.removeItem(at: workingURL)
+    }
+}

--- a/Berth/Core/SSH/DownloadDestinationTransaction.swift
+++ b/Berth/Core/SSH/DownloadDestinationTransaction.swift
@@ -10,13 +10,16 @@ import Foundation
 /// 5. 取消或失败时 discard 删除 working path, 原 finalURL 完好无损。
 public struct DownloadDestinationTransaction: Sendable {
     public enum TransactionError: LocalizedError, Equatable {
-        case destinationDirectoryNotEmpty(URL)
+        case destinationDirectoryAlreadyExists(URL)
+        case workingItemMissing(URL)
         case invalidParentDirectory(URL)
 
         public var errorDescription: String? {
             switch self {
-            case .destinationDirectoryNotEmpty(let url):
-                return String(localized: "目标目录已存在且不为空: \(url.lastPathComponent)")
+            case .destinationDirectoryAlreadyExists(let url):
+                return String(localized: "目标目录已存在: \(url.lastPathComponent)")
+            case .workingItemMissing(let url):
+                return String(localized: "下载临时工作项不存在: \(url.lastPathComponent)")
             case .invalidParentDirectory(let url):
                 return String(localized: "目标父目录无效: \(url.path)")
             }
@@ -77,8 +80,8 @@ public struct DownloadDestinationTransaction: Sendable {
 
     public func commit() throws {
         guard fileManager.fileExists(atPath: workingURL.path) else {
-            // 若 workingURL 未在磁盘上物化（例如仅在内存中模拟的测试执行器），无需也无法提交到 finalURL
-            return
+            // fail-closed: 临时工作项不存在时绝对不得假装提交成功
+            throw TransactionError.workingItemMissing(workingURL)
         }
 
         var isDir: ObjCBool = false
@@ -95,17 +98,11 @@ public struct DownloadDestinationTransaction: Sendable {
                 backupItemName: nil,
                 options: []
             )
-        } else if isDirectory && isDir.boolValue {
-            // final 是已存在目录: 如果非空则拒绝静默合并, 避免不可逆覆盖
-            let contents = try fileManager.contentsOfDirectory(atPath: finalURL.path)
-            if contents.isEmpty {
-                try fileManager.removeItem(at: finalURL)
-                try fileManager.moveItem(at: workingURL, to: finalURL)
-            } else {
-                throw TransactionError.destinationDirectoryNotEmpty(finalURL)
-            }
+        } else if isDir.boolValue {
+            // final 是已存在目录 (无论空或非空): 一律拒绝替换, 绝不通过 remove + move 等非事务窗口操作
+            throw TransactionError.destinationDirectoryAlreadyExists(finalURL)
         } else {
-            // 文件与目录类型冲突
+            // 文件与目录类型冲突 (例如 final 是已存在文件但下载的是目录)
             throw CocoaError(.fileWriteFileExists)
         }
     }

--- a/Berth/Core/SSH/DownloadDestinationTransaction.swift
+++ b/Berth/Core/SSH/DownloadDestinationTransaction.swift
@@ -1,14 +1,310 @@
+import Darwin
 import Foundation
+
+struct DownloadTransactionSweepResult: Sendable, Equatable {
+    let examinedCount: Int
+    let reclaimedCount: Int
+}
+
+private struct DownloadTransactionManifest: Codable, Sendable {
+    let schemaVersion: Int
+    let id: UUID
+    let createdAt: Date
+    let finalPath: String
+    let workingPath: String
+    let isDirectory: Bool
+}
+
+/// 持有一个跨进程 advisory lock。进程崩溃时内核会自动释放锁，但 manifest 会保留，
+/// 下次启动即可精确回收对应的 working item。
+final class DownloadTransactionLease: @unchecked Sendable {
+    let id: UUID
+    private let markerURL: URL
+    private let lockURL: URL
+    private let fileManager: FileManager
+    private let stateLock = NSLock()
+    private var lockFileDescriptor: Int32
+
+    init(
+        id: UUID,
+        markerURL: URL,
+        lockURL: URL,
+        lockFileDescriptor: Int32,
+        fileManager: FileManager
+    ) {
+        self.id = id
+        self.markerURL = markerURL
+        self.lockURL = lockURL
+        self.lockFileDescriptor = lockFileDescriptor
+        self.fileManager = fileManager
+    }
+
+    deinit {
+        abandon()
+    }
+
+    /// 正常完成：删除 manifest/lock 文件并释放内核锁。
+    func complete() {
+        release(removeRegistration: true)
+    }
+
+    /// 无法立即清理 working item：仅释放锁，保留 manifest 供后续 sweep 重试。
+    func abandon() {
+        release(removeRegistration: false)
+    }
+
+    private func release(removeRegistration: Bool) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard lockFileDescriptor >= 0 else { return }
+
+        if removeRegistration {
+            do {
+                if fileManager.fileExists(atPath: markerURL.path) {
+                    try fileManager.removeItem(at: markerURL)
+                }
+            } catch {
+                DebugLog.append("download transaction marker cleanup failed id=\(id) error=\(error)")
+            }
+            do {
+                if fileManager.fileExists(atPath: lockURL.path) {
+                    try fileManager.removeItem(at: lockURL)
+                }
+            } catch {
+                DebugLog.append("download transaction lock cleanup failed id=\(id) error=\(error)")
+            }
+        }
+
+        _ = flock(lockFileDescriptor, LOCK_UN)
+        _ = Darwin.close(lockFileDescriptor)
+        lockFileDescriptor = -1
+    }
+}
+
+/// 普通“下载…”事务的持久化登记表。
+/// manifest 只记录精确的 final/working 路径；活跃事务用 flock 跨进程保护，崩溃后锁自动释放。
+final class DownloadTransactionRegistry: @unchecked Sendable {
+    static let shared = DownloadTransactionRegistry(baseDirectory: defaultBaseDirectory)
+
+    private static let defaultBaseDirectory: URL = {
+        let root = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        return root
+            .appendingPathComponent("Berth", isDirectory: true)
+            .appendingPathComponent("DownloadTransactions", isDirectory: true)
+    }()
+
+    let baseDirectory: URL
+    private let fileManager: FileManager
+
+    init(baseDirectory: URL, fileManager: FileManager = .default) {
+        self.baseDirectory = baseDirectory
+        self.fileManager = fileManager
+    }
+
+    func register(
+        id: UUID,
+        finalURL: URL,
+        workingURL: URL,
+        isDirectory: Bool,
+        createdAt: Date = Date()
+    ) throws -> DownloadTransactionLease {
+        try fileManager.createDirectory(at: baseDirectory, withIntermediateDirectories: true)
+
+        let markerURL = self.markerURL(for: id)
+        let lockURL = self.lockURL(for: id)
+        let descriptor = openLockFile(at: lockURL)
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            let code = POSIXErrorCode(rawValue: errno) ?? .EIO
+            _ = Darwin.close(descriptor)
+            throw POSIXError(code)
+        }
+
+        do {
+            let manifest = DownloadTransactionManifest(
+                schemaVersion: 1,
+                id: id,
+                createdAt: createdAt,
+                finalPath: finalURL.path,
+                workingPath: workingURL.path,
+                isDirectory: isDirectory
+            )
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            try encoder.encode(manifest).write(to: markerURL, options: .atomic)
+        } catch {
+            _ = flock(descriptor, LOCK_UN)
+            _ = Darwin.close(descriptor)
+            try? fileManager.removeItem(at: markerURL)
+            try? fileManager.removeItem(at: lockURL)
+            throw error
+        }
+
+        return DownloadTransactionLease(
+            id: id,
+            markerURL: markerURL,
+            lockURL: lockURL,
+            lockFileDescriptor: descriptor,
+            fileManager: fileManager
+        )
+    }
+
+    @discardableResult
+    func sweepOrphans() throws -> DownloadTransactionSweepResult {
+        guard fileManager.fileExists(atPath: baseDirectory.path) else {
+            return DownloadTransactionSweepResult(examinedCount: 0, reclaimedCount: 0)
+        }
+
+        let entries = try fileManager.contentsOfDirectory(
+            at: baseDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles]
+        )
+        var examined = 0
+        var reclaimed = 0
+
+        for markerURL in entries where markerURL.pathExtension == "json" {
+            examined += 1
+            let markerValues = try? markerURL.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+            guard markerValues?.isRegularFile == true, markerValues?.isSymbolicLink != true else { continue }
+            let rawID = markerURL.deletingPathExtension().lastPathComponent
+            guard let id = UUID(uuidString: rawID) else { continue }
+            let lockURL = self.lockURL(for: id)
+            let descriptor = openLockFile(at: lockURL)
+            guard descriptor >= 0 else { continue }
+
+            guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+                _ = Darwin.close(descriptor)
+                continue
+            }
+
+            let didReclaim = reclaimOrphan(
+                id: id,
+                markerURL: markerURL,
+                lockURL: lockURL
+            )
+            if didReclaim { reclaimed += 1 }
+            if !fileManager.fileExists(atPath: markerURL.path) {
+                // 正常完成可能恰好发生在枚举之后；此时 openLockFile 会重建一个空 lock。
+                // marker 已不存在，安全删除这个无主的小文件，避免竞态累积。
+                try? fileManager.removeItem(at: lockURL)
+            }
+            _ = flock(descriptor, LOCK_UN)
+            _ = Darwin.close(descriptor)
+        }
+
+        if reclaimed > 0 {
+            DebugLog.append("download transaction sweep examined=\(examined) reclaimed=\(reclaimed)")
+        }
+        return DownloadTransactionSweepResult(examinedCount: examined, reclaimedCount: reclaimed)
+    }
+
+    private func reclaimOrphan(id: UUID, markerURL: URL, lockURL: URL) -> Bool {
+        guard let data = try? Data(contentsOf: markerURL) else { return false }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let manifest = try? decoder.decode(DownloadTransactionManifest.self, from: data),
+              manifest.schemaVersion == 1,
+              manifest.id == id,
+              let workingURL = validatedWorkingURL(from: manifest)
+        else {
+            return false
+        }
+
+        let parentURL = workingURL.deletingLastPathComponent()
+        var parentIsDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: parentURL.path, isDirectory: &parentIsDirectory),
+              parentIsDirectory.boolValue
+        else {
+            // 外置磁盘或网络卷可能暂时离线；保留登记，待后续启动重试。
+            return false
+        }
+
+        do {
+            if fileManager.fileExists(atPath: workingURL.path) {
+                let values = try workingURL.resourceValues(
+                    forKeys: [.isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey]
+                )
+                guard values.isSymbolicLink != true,
+                      (manifest.isDirectory ? values.isDirectory == true : values.isRegularFile == true)
+                else {
+                    return false
+                }
+                try fileManager.removeItem(at: workingURL)
+            }
+            try? fileManager.removeItem(at: markerURL)
+            try? fileManager.removeItem(at: lockURL)
+            DebugLog.append("orphaned download transaction reclaimed id=\(id) name=\(LogSanitizer.safeFilename(workingURL.lastPathComponent))")
+            return true
+        } catch {
+            DebugLog.append("orphaned download transaction cleanup failed id=\(id) name=\(LogSanitizer.safeFilename(workingURL.lastPathComponent)) error=\(error)")
+            return false
+        }
+    }
+
+    private func validatedWorkingURL(from manifest: DownloadTransactionManifest) -> URL? {
+        let finalURL = URL(fileURLWithPath: manifest.finalPath).standardizedFileURL
+        let workingURL = URL(fileURLWithPath: manifest.workingPath).standardizedFileURL
+        guard finalURL.isFileURL, workingURL.isFileURL,
+              finalURL.deletingLastPathComponent().path == workingURL.deletingLastPathComponent().path,
+              !finalURL.lastPathComponent.isEmpty
+        else {
+            return nil
+        }
+
+        let expectedName = ".\(finalURL.lastPathComponent).berth-part-\(manifest.id.uuidString)"
+        guard workingURL.lastPathComponent == expectedName else { return nil }
+        return workingURL
+    }
+
+    private func markerURL(for id: UUID) -> URL {
+        baseDirectory.appendingPathComponent("\(id.uuidString).json", isDirectory: false)
+    }
+
+    private func lockURL(for id: UUID) -> URL {
+        baseDirectory.appendingPathComponent("\(id.uuidString).lock", isDirectory: false)
+    }
+
+    private func openLockFile(at url: URL) -> Int32 {
+        url.withUnsafeFileSystemRepresentation { path in
+            guard let path else {
+                errno = EINVAL
+                return -1
+            }
+            return Darwin.open(path, O_CREAT | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR)
+        }
+    }
+}
+
+/// 将目标路径检查、原子提交和递归清理隔离在后台 actor，避免大型目录取消或失败时
+/// 由 `SFTPBrowser` 的 MainActor 同步执行 FileManager 操作而冻结界面。
+actor DownloadDestinationTransactionWorker {
+    static let shared = DownloadDestinationTransactionWorker()
+
+    func begin(finalURL: URL, isDirectory: Bool) throws -> DownloadDestinationTransaction {
+        try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: isDirectory)
+    }
+
+    func commit(_ transaction: DownloadDestinationTransaction) throws {
+        try transaction.commit()
+    }
+
+    func discard(_ transaction: DownloadDestinationTransaction) {
+        transaction.discard()
+    }
+}
 
 /// 管理普通下载的目标路径事务提交。
 /// 保证:
 /// 1. 下载过程中不直接写入 finalURL, 也不提前 truncate 现有文件。
 /// 2. 在与 finalURL 同一父目录创建隐藏且带 UUID 的唯一 working path (.filename.berth-part-<UUID>),
 ///    保证原子重命名与多任务隔离。
-/// 3. 成功完成后原子提交为 finalURL (文件使用 replaceItemAt, 目录使用 rename)。
-/// 4. 目标目录若已存在且非空, 拒绝静默覆盖/合并, 抛出明确冲突。
-/// 5. 取消或失败时 discard 删除 working path, 原 finalURL 完好无损。
-public struct DownloadDestinationTransaction: Sendable {
+/// 3. final 不存在时原子 rename；已有文件时使用 renameatx_np(RENAME_SWAP) 原子交换。
+/// 4. 取消或失败时删除 working path；崩溃残留由持久化 registry 在下次启动安全回收。
+public struct DownloadDestinationTransaction: @unchecked Sendable {
     public enum TransactionError: LocalizedError, Equatable {
         case destinationDirectoryAlreadyExists(URL)
         case workingItemMissing(URL)
@@ -26,21 +322,29 @@ public struct DownloadDestinationTransaction: Sendable {
         }
     }
 
+    internal typealias ItemExchanger = @Sendable (URL, URL) throws -> Void
+
     public let finalURL: URL
     public let workingURL: URL
     public let isDirectory: Bool
     private let fileManager: FileManager
+    private let itemExchanger: ItemExchanger?
+    private let lease: DownloadTransactionLease
 
-    public init(
+    private init(
         finalURL: URL,
         workingURL: URL,
         isDirectory: Bool,
-        fileManager: FileManager = .default
+        fileManager: FileManager,
+        itemExchanger: ItemExchanger?,
+        lease: DownloadTransactionLease
     ) {
         self.finalURL = finalURL
         self.workingURL = workingURL
         self.isDirectory = isDirectory
         self.fileManager = fileManager
+        self.itemExchanger = itemExchanger
+        self.lease = lease
     }
 
     public static func begin(
@@ -48,66 +352,153 @@ public struct DownloadDestinationTransaction: Sendable {
         isDirectory: Bool,
         fileManager: FileManager = .default
     ) throws -> DownloadDestinationTransaction {
+        try begin(
+            finalURL: finalURL,
+            isDirectory: isDirectory,
+            fileManager: fileManager,
+            itemExchanger: nil,
+            registry: .shared
+        )
+    }
+
+    internal static func begin(
+        finalURL: URL,
+        isDirectory: Bool,
+        fileManager: FileManager = .default,
+        itemExchanger: ItemExchanger? = nil,
+        registry: DownloadTransactionRegistry
+    ) throws -> DownloadDestinationTransaction {
         let parentURL = finalURL.deletingLastPathComponent()
         guard parentURL.path != finalURL.path else {
             throw TransactionError.invalidParentDirectory(parentURL)
         }
 
         try fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
+        try LocalPathComponentValidator.validateComponent(finalURL.lastPathComponent)
 
-        let originalName = finalURL.lastPathComponent
-        try LocalPathComponentValidator.validateComponent(originalName)
+        // 目录下载不支持覆盖或合并；文件下载也不能替换现有目录。必须在创建
+        // working path/manifest 之前拒绝，避免大型远端目录完整传输后才失败。
+        var finalIsDirectory: ObjCBool = false
+        if fileManager.fileExists(atPath: finalURL.path, isDirectory: &finalIsDirectory) {
+            if finalIsDirectory.boolValue {
+                throw TransactionError.destinationDirectoryAlreadyExists(finalURL)
+            }
+            if isDirectory {
+                throw CocoaError(.fileWriteFileExists)
+            }
+        }
 
-        // 统一命名规则: .<originalName>.berth-part-<UUID>
-        let workingName = ".\(originalName).berth-part-\(UUID().uuidString)"
+        let id = UUID()
+        let workingName = ".\(finalURL.lastPathComponent).berth-part-\(id.uuidString)"
         let workingURL = try LocalPathComponentValidator.safeURL(
             in: parentURL,
             component: workingName,
             isDirectory: isDirectory
         )
+        let lease = try registry.register(
+            id: id,
+            finalURL: finalURL,
+            workingURL: workingURL,
+            isDirectory: isDirectory
+        )
 
-        if isDirectory {
-            try fileManager.createDirectory(at: workingURL, withIntermediateDirectories: true)
+        do {
+            if isDirectory {
+                try fileManager.createDirectory(at: workingURL, withIntermediateDirectories: true)
+            }
+        } catch {
+            lease.complete()
+            throw error
         }
 
         return DownloadDestinationTransaction(
             finalURL: finalURL,
             workingURL: workingURL,
             isDirectory: isDirectory,
-            fileManager: fileManager
+            fileManager: fileManager,
+            itemExchanger: itemExchanger,
+            lease: lease
         )
+    }
+
+    @discardableResult
+    static func sweepOrphans() throws -> DownloadTransactionSweepResult {
+        try DownloadTransactionRegistry.shared.sweepOrphans()
     }
 
     public func commit() throws {
         guard fileManager.fileExists(atPath: workingURL.path) else {
-            // fail-closed: 临时工作项不存在时绝对不得假装提交成功
+            lease.complete()
             throw TransactionError.workingItemMissing(workingURL)
         }
 
-        var isDir: ObjCBool = false
-        let finalExists = fileManager.fileExists(atPath: finalURL.path, isDirectory: &isDir)
+        var finalIsDirectory: ObjCBool = false
+        let finalExists = fileManager.fileExists(atPath: finalURL.path, isDirectory: &finalIsDirectory)
 
         if !finalExists {
-            // final 不存在: 原子移动
             try fileManager.moveItem(at: workingURL, to: finalURL)
-        } else if !isDirectory && !isDir.boolValue {
-            // final 是已存在文件: 原子替换
-            _ = try fileManager.replaceItemAt(
-                finalURL,
-                withItemAt: workingURL,
-                backupItemName: nil,
-                options: []
-            )
-        } else if isDir.boolValue {
-            // final 是已存在目录 (无论空或非空): 一律拒绝替换, 绝不通过 remove + move 等非事务窗口操作
+            lease.complete()
+        } else if !isDirectory && !finalIsDirectory.boolValue {
+            if let itemExchanger {
+                try itemExchanger(workingURL, finalURL)
+            } else {
+                try Self.exchangeItemsAtomically(workingURL, finalURL)
+            }
+
+            // 原子交换已经是 commit point。workingURL 现在保存旧 final；清理失败时保留
+            // registry，让下次启动重试，不能把已成功提交的新 final 回报成失败。
+            do {
+                try fileManager.removeItem(at: workingURL)
+                lease.complete()
+            } catch {
+                lease.abandon()
+                DebugLog.append("download transaction old item cleanup deferred name=\(LogSanitizer.safeFilename(workingURL.lastPathComponent)) error=\(error)")
+            }
+        } else if finalIsDirectory.boolValue {
             throw TransactionError.destinationDirectoryAlreadyExists(finalURL)
         } else {
-            // 文件与目录类型冲突 (例如 final 是已存在文件但下载的是目录)
             throw CocoaError(.fileWriteFileExists)
         }
     }
 
     public func discard() {
-        try? fileManager.removeItem(at: workingURL)
+        do {
+            if fileManager.fileExists(atPath: workingURL.path) {
+                try fileManager.removeItem(at: workingURL)
+            }
+            lease.complete()
+        } catch {
+            lease.abandon()
+            DebugLog.append("download transaction discard deferred name=\(LogSanitizer.safeFilename(workingURL.lastPathComponent)) error=\(error)")
+        }
+    }
+
+    /// 测试中模拟进程在未执行 discard 的情况下退出；生产崩溃由内核自动释放 flock。
+    internal func abandonWithoutCleanup() {
+        lease.abandon()
+    }
+
+    private static func exchangeItemsAtomically(_ lhs: URL, _ rhs: URL) throws {
+        var callErrno: Int32 = 0
+        let result: Int32 = lhs.withUnsafeFileSystemRepresentation { lhsPath in
+            rhs.withUnsafeFileSystemRepresentation { rhsPath in
+                guard let lhsPath, let rhsPath else {
+                    callErrno = EINVAL
+                    return -1
+                }
+                let result = Darwin.renameatx_np(
+                    AT_FDCWD,
+                    lhsPath,
+                    AT_FDCWD,
+                    rhsPath,
+                    UInt32(RENAME_SWAP)
+                )
+                if result != 0 { callErrno = errno }
+                return result
+            }
+        }
+        guard result == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: callErrno) ?? .EIO)
+        }
     }
 }

--- a/Berth/Core/SSH/DownloadDestinationTransaction.swift
+++ b/Berth/Core/SSH/DownloadDestinationTransaction.swift
@@ -285,10 +285,12 @@ actor DownloadDestinationTransactionWorker {
     static let shared = DownloadDestinationTransactionWorker()
 
     func begin(finalURL: URL, isDirectory: Bool) throws -> DownloadDestinationTransaction {
+        try Task.checkCancellation()
         try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: isDirectory)
     }
 
     func commit(_ transaction: DownloadDestinationTransaction) throws {
+        try Task.checkCancellation()
         try transaction.commit()
     }
 

--- a/Berth/Core/SSH/DownloadDestinationTransaction.swift
+++ b/Berth/Core/SSH/DownloadDestinationTransaction.swift
@@ -286,7 +286,7 @@ actor DownloadDestinationTransactionWorker {
 
     func begin(finalURL: URL, isDirectory: Bool) throws -> DownloadDestinationTransaction {
         try Task.checkCancellation()
-        try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: isDirectory)
+        return try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: isDirectory)
     }
 
     func commit(_ transaction: DownloadDestinationTransaction) throws {

--- a/Berth/Core/SSH/DownloadDestinationTransaction.swift
+++ b/Berth/Core/SSH/DownloadDestinationTransaction.swift
@@ -13,6 +13,37 @@ private struct DownloadTransactionManifest: Codable, Sendable {
     let finalPath: String
     let workingPath: String
     let isDirectory: Bool
+
+    var finalURL: URL {
+        URL(fileURLWithPath: finalPath).standardizedFileURL
+    }
+
+    var workingURL: URL {
+        URL(fileURLWithPath: workingPath).standardizedFileURL
+    }
+}
+
+/// 独占持有一个 advisory lock descriptor，并保证所有退出路径只释放一次。
+private final class DownloadTransactionFileLock: @unchecked Sendable {
+    private let stateLock = NSLock()
+    private var descriptor: Int32
+
+    init(descriptor: Int32) {
+        self.descriptor = descriptor
+    }
+
+    deinit {
+        release()
+    }
+
+    func release() {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard descriptor >= 0 else { return }
+        _ = flock(descriptor, LOCK_UN)
+        _ = Darwin.close(descriptor)
+        descriptor = -1
+    }
 }
 
 /// 持有一个跨进程 advisory lock。进程崩溃时内核会自动释放锁，但 manifest 会保留，
@@ -23,19 +54,20 @@ final class DownloadTransactionLease: @unchecked Sendable {
     private let lockURL: URL
     private let fileManager: FileManager
     private let stateLock = NSLock()
-    private var lockFileDescriptor: Int32
+    private let fileLock: DownloadTransactionFileLock
+    private var isReleased = false
 
-    init(
+    fileprivate init(
         id: UUID,
         markerURL: URL,
         lockURL: URL,
-        lockFileDescriptor: Int32,
+        fileLock: DownloadTransactionFileLock,
         fileManager: FileManager
     ) {
         self.id = id
         self.markerURL = markerURL
         self.lockURL = lockURL
-        self.lockFileDescriptor = lockFileDescriptor
+        self.fileLock = fileLock
         self.fileManager = fileManager
     }
 
@@ -56,7 +88,8 @@ final class DownloadTransactionLease: @unchecked Sendable {
     private func release(removeRegistration: Bool) {
         stateLock.lock()
         defer { stateLock.unlock() }
-        guard lockFileDescriptor >= 0 else { return }
+        guard !isReleased else { return }
+        isReleased = true
 
         if removeRegistration {
             do {
@@ -75,9 +108,7 @@ final class DownloadTransactionLease: @unchecked Sendable {
             }
         }
 
-        _ = flock(lockFileDescriptor, LOCK_UN)
-        _ = Darwin.close(lockFileDescriptor)
-        lockFileDescriptor = -1
+        fileLock.release()
     }
 }
 
@@ -85,6 +116,7 @@ final class DownloadTransactionLease: @unchecked Sendable {
 /// manifest 只记录精确的 final/working 路径；活跃事务用 flock 跨进程保护，崩溃后锁自动释放。
 final class DownloadTransactionRegistry: @unchecked Sendable {
     static let shared = DownloadTransactionRegistry(baseDirectory: defaultBaseDirectory)
+    static let defaultOrphanGracePeriod: TimeInterval = 60 * 60
 
     private static let defaultBaseDirectory: URL = {
         let root = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
@@ -95,65 +127,50 @@ final class DownloadTransactionRegistry: @unchecked Sendable {
     }()
 
     let baseDirectory: URL
+    let orphanGracePeriod: TimeInterval
     private let fileManager: FileManager
 
-    init(baseDirectory: URL, fileManager: FileManager = .default) {
+    init(
+        baseDirectory: URL,
+        orphanGracePeriod: TimeInterval = DownloadTransactionRegistry.defaultOrphanGracePeriod,
+        fileManager: FileManager = .default
+    ) {
         self.baseDirectory = baseDirectory
+        self.orphanGracePeriod = orphanGracePeriod
         self.fileManager = fileManager
     }
 
-    func register(
-        id: UUID,
-        finalURL: URL,
-        workingURL: URL,
-        isDirectory: Bool,
-        createdAt: Date = Date()
-    ) throws -> DownloadTransactionLease {
+    fileprivate func register(_ manifest: DownloadTransactionManifest) throws -> DownloadTransactionLease {
         try fileManager.createDirectory(at: baseDirectory, withIntermediateDirectories: true)
 
-        let markerURL = self.markerURL(for: id)
-        let lockURL = self.lockURL(for: id)
-        let descriptor = openLockFile(at: lockURL)
-        guard descriptor >= 0 else {
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
-        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
-            let code = POSIXErrorCode(rawValue: errno) ?? .EIO
-            _ = Darwin.close(descriptor)
-            throw POSIXError(code)
+        let markerURL = self.markerURL(for: manifest.id)
+        let lockURL = self.lockURL(for: manifest.id)
+        guard let fileLock = try acquireLock(at: lockURL) else {
+            throw POSIXError(.EWOULDBLOCK)
         }
 
         do {
-            let manifest = DownloadTransactionManifest(
-                schemaVersion: 1,
-                id: id,
-                createdAt: createdAt,
-                finalPath: finalURL.path,
-                workingPath: workingURL.path,
-                isDirectory: isDirectory
-            )
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = .iso8601
             try encoder.encode(manifest).write(to: markerURL, options: .atomic)
         } catch {
-            _ = flock(descriptor, LOCK_UN)
-            _ = Darwin.close(descriptor)
+            fileLock.release()
             try? fileManager.removeItem(at: markerURL)
             try? fileManager.removeItem(at: lockURL)
             throw error
         }
 
         return DownloadTransactionLease(
-            id: id,
+            id: manifest.id,
             markerURL: markerURL,
             lockURL: lockURL,
-            lockFileDescriptor: descriptor,
+            fileLock: fileLock,
             fileManager: fileManager
         )
     }
 
     @discardableResult
-    func sweepOrphans() throws -> DownloadTransactionSweepResult {
+    func sweepOrphans(now: Date = Date()) throws -> DownloadTransactionSweepResult {
         guard fileManager.fileExists(atPath: baseDirectory.path) else {
             return DownloadTransactionSweepResult(examinedCount: 0, reclaimedCount: 0)
         }
@@ -173,18 +190,20 @@ final class DownloadTransactionRegistry: @unchecked Sendable {
             let rawID = markerURL.deletingPathExtension().lastPathComponent
             guard let id = UUID(uuidString: rawID) else { continue }
             let lockURL = self.lockURL(for: id)
-            let descriptor = openLockFile(at: lockURL)
-            guard descriptor >= 0 else { continue }
-
-            guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
-                _ = Darwin.close(descriptor)
+            let fileLock: DownloadTransactionFileLock
+            do {
+                guard let acquiredLock = try acquireLock(at: lockURL) else { continue }
+                fileLock = acquiredLock
+            } catch {
                 continue
             }
+            defer { fileLock.release() }
 
             let didReclaim = reclaimOrphan(
                 id: id,
                 markerURL: markerURL,
-                lockURL: lockURL
+                lockURL: lockURL,
+                now: now
             )
             if didReclaim { reclaimed += 1 }
             if !fileManager.fileExists(atPath: markerURL.path) {
@@ -192,8 +211,6 @@ final class DownloadTransactionRegistry: @unchecked Sendable {
                 // marker 已不存在，安全删除这个无主的小文件，避免竞态累积。
                 try? fileManager.removeItem(at: lockURL)
             }
-            _ = flock(descriptor, LOCK_UN)
-            _ = Darwin.close(descriptor)
         }
 
         if reclaimed > 0 {
@@ -202,7 +219,12 @@ final class DownloadTransactionRegistry: @unchecked Sendable {
         return DownloadTransactionSweepResult(examinedCount: examined, reclaimedCount: reclaimed)
     }
 
-    private func reclaimOrphan(id: UUID, markerURL: URL, lockURL: URL) -> Bool {
+    private func reclaimOrphan(
+        id: UUID,
+        markerURL: URL,
+        lockURL: URL,
+        now: Date
+    ) -> Bool {
         guard let data = try? Data(contentsOf: markerURL) else { return false }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
@@ -211,6 +233,12 @@ final class DownloadTransactionRegistry: @unchecked Sendable {
               manifest.id == id,
               let workingURL = validatedWorkingURL(from: manifest)
         else {
+            return false
+        }
+        // A released lock proves there is no active writer, but it does not make a just-created
+        // partial old enough to reclaim. Preserve recent crash artefacts until the conservative
+        // TTL expires, as required by the destination transaction ownership contract.
+        guard now.timeIntervalSince(manifest.createdAt) >= orphanGracePeriod else {
             return false
         }
 
@@ -246,8 +274,8 @@ final class DownloadTransactionRegistry: @unchecked Sendable {
     }
 
     private func validatedWorkingURL(from manifest: DownloadTransactionManifest) -> URL? {
-        let finalURL = URL(fileURLWithPath: manifest.finalPath).standardizedFileURL
-        let workingURL = URL(fileURLWithPath: manifest.workingPath).standardizedFileURL
+        let finalURL = manifest.finalURL
+        let workingURL = manifest.workingURL
         guard finalURL.isFileURL, workingURL.isFileURL,
               finalURL.deletingLastPathComponent().path == workingURL.deletingLastPathComponent().path,
               !finalURL.lastPathComponent.isEmpty
@@ -268,14 +296,26 @@ final class DownloadTransactionRegistry: @unchecked Sendable {
         baseDirectory.appendingPathComponent("\(id.uuidString).lock", isDirectory: false)
     }
 
-    private func openLockFile(at url: URL) -> Int32 {
-        url.withUnsafeFileSystemRepresentation { path in
+    private func acquireLock(at url: URL) throws -> DownloadTransactionFileLock? {
+        let descriptor: Int32 = url.withUnsafeFileSystemRepresentation { path -> Int32 in
             guard let path else {
                 errno = EINVAL
                 return -1
             }
             return Darwin.open(path, O_CREAT | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR)
         }
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            let code = errno
+            _ = Darwin.close(descriptor)
+            if code == EWOULDBLOCK || code == EAGAIN {
+                return nil
+            }
+            throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+        }
+        return DownloadTransactionFileLock(descriptor: descriptor)
     }
 }
 
@@ -326,24 +366,21 @@ public struct DownloadDestinationTransaction: @unchecked Sendable {
 
     internal typealias ItemExchanger = @Sendable (URL, URL) throws -> Void
 
-    public let finalURL: URL
-    public let workingURL: URL
-    public let isDirectory: Bool
+    public var finalURL: URL { manifest.finalURL }
+    public var workingURL: URL { manifest.workingURL }
+    public var isDirectory: Bool { manifest.isDirectory }
+    private let manifest: DownloadTransactionManifest
     private let fileManager: FileManager
     private let itemExchanger: ItemExchanger?
     private let lease: DownloadTransactionLease
 
     private init(
-        finalURL: URL,
-        workingURL: URL,
-        isDirectory: Bool,
+        manifest: DownloadTransactionManifest,
         fileManager: FileManager,
         itemExchanger: ItemExchanger?,
         lease: DownloadTransactionLease
     ) {
-        self.finalURL = finalURL
-        self.workingURL = workingURL
-        self.isDirectory = isDirectory
+        self.manifest = manifest
         self.fileManager = fileManager
         self.itemExchanger = itemExchanger
         self.lease = lease
@@ -366,6 +403,7 @@ public struct DownloadDestinationTransaction: @unchecked Sendable {
     internal static func begin(
         finalURL: URL,
         isDirectory: Bool,
+        createdAt: Date = Date(),
         fileManager: FileManager = .default,
         itemExchanger: ItemExchanger? = nil,
         registry: DownloadTransactionRegistry
@@ -397,12 +435,15 @@ public struct DownloadDestinationTransaction: @unchecked Sendable {
             component: workingName,
             isDirectory: isDirectory
         )
-        let lease = try registry.register(
+        let manifest = DownloadTransactionManifest(
+            schemaVersion: 1,
             id: id,
-            finalURL: finalURL,
-            workingURL: workingURL,
-            isDirectory: isDirectory
+            createdAt: createdAt,
+            finalPath: finalURL.path,
+            workingPath: workingURL.path,
+            isDirectory: isDirectory,
         )
+        let lease = try registry.register(manifest)
 
         do {
             if isDirectory {
@@ -414,9 +455,7 @@ public struct DownloadDestinationTransaction: @unchecked Sendable {
         }
 
         return DownloadDestinationTransaction(
-            finalURL: finalURL,
-            workingURL: workingURL,
-            isDirectory: isDirectory,
+            manifest: manifest,
             fileManager: fileManager,
             itemExchanger: itemExchanger,
             lease: lease
@@ -424,8 +463,8 @@ public struct DownloadDestinationTransaction: @unchecked Sendable {
     }
 
     @discardableResult
-    static func sweepOrphans() throws -> DownloadTransactionSweepResult {
-        try DownloadTransactionRegistry.shared.sweepOrphans()
+    static func sweepOrphans(now: Date = Date()) throws -> DownloadTransactionSweepResult {
+        try DownloadTransactionRegistry.shared.sweepOrphans(now: now)
     }
 
     public func commit() throws {

--- a/Berth/Core/SSH/DownloadDestinationTransaction.swift
+++ b/Berth/Core/SSH/DownloadDestinationTransaction.swift
@@ -486,10 +486,13 @@ public struct DownloadDestinationTransaction: @unchecked Sendable {
                 try Self.exchangeItemsAtomically(workingURL, finalURL)
             }
 
-            // 原子交换已经是 commit point。workingURL 现在保存旧 final；清理失败时保留
-            // registry，让下次启动重试，不能把已成功提交的新 final 回报成失败。
+            // 原子交换已经是 commit point。RENAME_SWAP 成功时 workingURL 保存旧 final，
+            // rename(2) 回落路径下 working 已被消费；清理失败时保留 registry，让下次启动
+            // 重试，不能把已成功提交的新 final 回报成失败。
             do {
-                try fileManager.removeItem(at: workingURL)
+                if fileManager.fileExists(atPath: workingURL.path) {
+                    try fileManager.removeItem(at: workingURL)
+                }
                 lease.complete()
             } catch {
                 lease.abandon()
@@ -519,6 +522,8 @@ public struct DownloadDestinationTransaction: @unchecked Sendable {
         lease.abandon()
     }
 
+    /// 优先 renameatx_np(RENAME_SWAP)（APFS/HFS+，旧文件留在 lhs 供调用方清理）；exFAT、SMB、
+    /// NFS 等不支持交换的卷回落到 rename(2)：POSIX 语义下同样是原子替换，只是旧文件直接被覆盖。
     private static func exchangeItemsAtomically(_ lhs: URL, _ rhs: URL) throws {
         var callErrno: Int32 = 0
         let result: Int32 = lhs.withUnsafeFileSystemRepresentation { lhsPath in
@@ -527,15 +532,21 @@ public struct DownloadDestinationTransaction: @unchecked Sendable {
                     callErrno = EINVAL
                     return -1
                 }
-                let result = Darwin.renameatx_np(
+                let swapped = Darwin.renameatx_np(
                     AT_FDCWD,
                     lhsPath,
                     AT_FDCWD,
                     rhsPath,
                     UInt32(RENAME_SWAP)
                 )
-                if result != 0 { callErrno = errno }
-                return result
+                if swapped == 0 { return 0 }
+                guard errno == ENOTSUP || errno == EINVAL else {
+                    callErrno = errno
+                    return -1
+                }
+                let renamed = Darwin.rename(lhsPath, rhsPath)
+                if renamed != 0 { callErrno = errno }
+                return renamed
             }
         }
         guard result == 0 else {

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -388,12 +388,22 @@ final class SFTPBrowser {
 
     func download(_ entry: Entry, to localURL: URL) async {
         do {
-            try await performDownload(
-                entry,
-                remoteDirectory: path,
-                to: localURL,
-                externalProgress: nil
+            let tx = try DownloadDestinationTransaction.begin(
+                finalURL: localURL,
+                isDirectory: entry.isDirectory
             )
+            do {
+                try await performDownload(
+                    entry,
+                    remoteDirectory: path,
+                    to: tx.workingURL,
+                    externalProgress: nil
+                )
+                try tx.commit()
+            } catch {
+                tx.discard()
+                throw error
+            }
         } catch where SFTPTransferCancellation.isCancellation(error) {
             // 用户主动取消, 不改变 state 为 .failed
         } catch {

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -388,20 +388,23 @@ final class SFTPBrowser {
 
     func download(_ entry: Entry, to localURL: URL) async {
         do {
-            let tx = try DownloadDestinationTransaction.begin(
+            let worker = DownloadDestinationTransactionWorker.shared
+            let tx = try await worker.begin(
                 finalURL: localURL,
                 isDirectory: entry.isDirectory
             )
             do {
+                try Task.checkCancellation()
                 try await performDownload(
                     entry,
                     remoteDirectory: path,
                     to: tx.workingURL,
                     externalProgress: nil
                 )
-                try tx.commit()
+                try Task.checkCancellation()
+                try await worker.commit(tx)
             } catch {
-                tx.discard()
+                await worker.discard(tx)
                 throw error
             }
         } catch where SFTPTransferCancellation.isCancellation(error) {
@@ -508,7 +511,13 @@ final class SFTPBrowser {
         }
 
         return try await withTaskCancellationHandler {
-            try await transferTask.value
+            let result = try await transferTask.value
+            // Task cancellation is cooperative: a custom/finishing executor may return success
+            // after cancelTransfer() has already cancelled it. Never let that race reach commit().
+            if transferTask.isCancelled || Task.isCancelled {
+                throw CancellationError()
+            }
+            return result
         } onCancel: {
             transferTask.cancel()
         }

--- a/Berth/Core/SSH/SFTPBrowser.swift
+++ b/Berth/Core/SSH/SFTPBrowser.swift
@@ -388,6 +388,10 @@ final class SFTPBrowser {
 
     func download(_ entry: Entry, to localURL: URL) async {
         do {
+            // Freeze the selected remote directory before the first suspension. Destination
+            // preparation performs file-system work on another actor; the user may navigate the
+            // SFTP panel while it is running, but that must not retarget this download.
+            let remoteDirectory = path
             let worker = DownloadDestinationTransactionWorker.shared
             let tx = try await worker.begin(
                 finalURL: localURL,
@@ -397,7 +401,7 @@ final class SFTPBrowser {
                 try Task.checkCancellation()
                 try await performDownload(
                     entry,
-                    remoteDirectory: path,
+                    remoteDirectory: remoteDirectory,
                     to: tx.workingURL,
                     externalProgress: nil
                 )

--- a/Berth/Debug/M2AcceptanceTest.swift
+++ b/Berth/Debug/M2AcceptanceTest.swift
@@ -414,8 +414,9 @@ enum M2AcceptanceTest {
             return false
         }
 
+        // 目录下载不再合并进已有目录(DownloadDestinationTransaction 预检拒绝):目标必须不存在
         let downRoot = localRoot.appendingPathComponent("down", isDirectory: true)
-        try? fm.createDirectory(at: downRoot, withIntermediateDirectories: true)
+        try? fm.removeItem(at: downRoot)
         await browser.download(remoteDir, to: downRoot)
 
         let gotAlpha = (try? Data(contentsOf: downRoot.appendingPathComponent("a.txt"))) == alpha

--- a/Berth/Resources/Localizable.xcstrings
+++ b/Berth/Resources/Localizable.xcstrings
@@ -1635,6 +1635,16 @@
         }
       }
     },
+    "下载临时工作项不存在: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The temporary download item is missing: %@"
+          }
+        }
+      }
+    },
     "不使用": {
       "localizations": {
         "en": {
@@ -6437,12 +6447,32 @@
         }
       }
     },
+    "目标父目录无效: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid destination parent directory: %@"
+          }
+        }
+      }
+    },
     "目标目录 %@ 已存在:%@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Destination %@ already contains: %@"
+          }
+        }
+      }
+    },
+    "目标目录已存在: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destination folder already exists: %@"
           }
         }
       }

--- a/BerthTests/DownloadDestinationTransactionTests.swift
+++ b/BerthTests/DownloadDestinationTransactionTests.swift
@@ -122,53 +122,59 @@ final class DownloadDestinationTransactionTests: XCTestCase {
 
     // MARK: - 6. 目录 final 已存在 (空目录与非空目录): 均严格拒绝替换并保护原有目录
 
-    func testExistingEmptyDirectoryRefusesCommitAndPreservesFinal() throws {
+    func testExistingEmptyDirectoryRefusesBeginAndPreservesFinal() throws {
         let finalURL = tempDirectoryURL.appendingPathComponent("empty_existing_dir")
         try FileManager.default.createDirectory(at: finalURL, withIntermediateDirectories: true)
 
-        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: true)
-        try "REMOTE CONTENT".write(to: tx.workingURL.appendingPathComponent("remote.txt"), atomically: true, encoding: .utf8)
-
-        do {
-            try tx.commit()
-            XCTFail("Commit must throw when destination directory already exists")
-        } catch let error as DownloadDestinationTransaction.TransactionError {
-            XCTAssertEqual(error, .destinationDirectoryAlreadyExists(finalURL))
+        XCTAssertThrowsError(
+            try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: true)
+        ) { error in
+            XCTAssertEqual(
+                error as? DownloadDestinationTransaction.TransactionError,
+                .destinationDirectoryAlreadyExists(finalURL)
+            )
         }
-
-        // Clean up transaction
-        tx.discard()
 
         // Existing empty directory must NOT have been removed or merged
         XCTAssertTrue(FileManager.default.fileExists(atPath: finalURL.path))
         let remaining = try FileManager.default.contentsOfDirectory(atPath: finalURL.path)
         XCTAssertTrue(remaining.isEmpty, "Empty directory must remain empty and untouched")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+        XCTAssertFalse(try directoryContainsWorkingItem(for: finalURL))
     }
 
-    func testExistingNonEmptyDirectoryRefusesCommitAndPreservesFinal() throws {
+    func testExistingNonEmptyDirectoryRefusesBeginAndPreservesFinal() throws {
         let finalURL = tempDirectoryURL.appendingPathComponent("existing_folder")
         try FileManager.default.createDirectory(at: finalURL, withIntermediateDirectories: true)
         try "IMPORTANT LOCAL FILE".write(to: finalURL.appendingPathComponent("local.txt"), atomically: true, encoding: .utf8)
 
-        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: true)
-        try "REMOTE NEW FILE".write(to: tx.workingURL.appendingPathComponent("remote.txt"), atomically: true, encoding: .utf8)
-
-        do {
-            try tx.commit()
-            XCTFail("Commit must throw when destination directory already exists and is non-empty")
-        } catch let error as DownloadDestinationTransaction.TransactionError {
-            XCTAssertEqual(error, .destinationDirectoryAlreadyExists(finalURL))
+        XCTAssertThrowsError(
+            try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: true)
+        ) { error in
+            XCTAssertEqual(
+                error as? DownloadDestinationTransaction.TransactionError,
+                .destinationDirectoryAlreadyExists(finalURL)
+            )
         }
-
-        // Clean up transaction
-        tx.discard()
 
         // Existing folder must remain completely intact
         XCTAssertTrue(FileManager.default.fileExists(atPath: finalURL.appendingPathComponent("local.txt").path))
         let content = try String(contentsOf: finalURL.appendingPathComponent("local.txt"), encoding: .utf8)
         XCTAssertEqual(content, "IMPORTANT LOCAL FILE")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+        XCTAssertFalse(try directoryContainsWorkingItem(for: finalURL))
+    }
+
+    func testDirectoryDownloadRefusesExistingFileBeforeCreatingWorkingItem() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("existing_file")
+        try "LOCAL DATA".write(to: finalURL, atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(
+            try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: true)
+        ) { error in
+            XCTAssertEqual((error as? CocoaError)?.code, .fileWriteFileExists)
+        }
+
+        XCTAssertEqual(try String(contentsOf: finalURL, encoding: .utf8), "LOCAL DATA")
+        XCTAssertFalse(try directoryContainsWorkingItem(for: finalURL))
     }
 
     // MARK: - 7. 目录下载取消: working 树被完全删除, final 不存在
@@ -285,5 +291,105 @@ final class DownloadDestinationTransactionTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: finalURL), originalBytes)
         XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
         XCTAssertEqual(simulatedError.code, .ENOSPC)
+    }
+
+    // MARK: - 11. 原子交换与崩溃恢复
+
+    func testAtomicExchangeFailureLeavesOriginalAtFinal() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("exchange_failure.bin")
+        try "ORIGINAL DATA".write(to: finalURL, atomically: true, encoding: .utf8)
+
+        struct SimulatedExchangeError: Error, Equatable {}
+        let registry = DownloadTransactionRegistry(
+            baseDirectory: tempDirectoryURL.appendingPathComponent("registry", isDirectory: true)
+        )
+        let tx = try DownloadDestinationTransaction.begin(
+            finalURL: finalURL,
+            isDirectory: false,
+            itemExchanger: { _, _ in throw SimulatedExchangeError() },
+            registry: registry
+        )
+        try "NEW CONTENT".write(to: tx.workingURL, atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(try tx.commit()) { error in
+            XCTAssertTrue(error is SimulatedExchangeError)
+        }
+        XCTAssertEqual(try String(contentsOf: finalURL, encoding: .utf8), "ORIGINAL DATA")
+        XCTAssertEqual(try String(contentsOf: tx.workingURL, encoding: .utf8), "NEW CONTENT")
+
+        tx.discard()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+    }
+
+    func testSweepDoesNotRemoveActiveTransaction() throws {
+        let registry = DownloadTransactionRegistry(
+            baseDirectory: tempDirectoryURL.appendingPathComponent("active-registry", isDirectory: true)
+        )
+        let finalURL = tempDirectoryURL.appendingPathComponent("active.bin")
+        let tx = try DownloadDestinationTransaction.begin(
+            finalURL: finalURL,
+            isDirectory: false,
+            registry: registry
+        )
+        try "PARTIAL".write(to: tx.workingURL, atomically: true, encoding: .utf8)
+
+        // 另一实例使用独立 registry 对象打开同一 lock 文件，模拟第二个 Berth 进程 sweep。
+        let sweeper = DownloadTransactionRegistry(baseDirectory: registry.baseDirectory)
+        let result = try sweeper.sweepOrphans()
+
+        XCTAssertEqual(result.examinedCount, 1)
+        XCTAssertEqual(result.reclaimedCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tx.workingURL.path))
+        tx.discard()
+    }
+
+    func testSweepRemovesAbandonedFileTransaction() throws {
+        let registry = DownloadTransactionRegistry(
+            baseDirectory: tempDirectoryURL.appendingPathComponent("orphan-registry", isDirectory: true)
+        )
+        let finalURL = tempDirectoryURL.appendingPathComponent("orphan.bin")
+        let tx = try DownloadDestinationTransaction.begin(
+            finalURL: finalURL,
+            isDirectory: false,
+            registry: registry
+        )
+        try "PARTIAL".write(to: tx.workingURL, atomically: true, encoding: .utf8)
+        tx.abandonWithoutCleanup()
+
+        let result = try registry.sweepOrphans()
+
+        XCTAssertEqual(result.reclaimedCount, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: finalURL.path))
+    }
+
+    func testSweepRemovesAbandonedDirectoryTransaction() throws {
+        let registry = DownloadTransactionRegistry(
+            baseDirectory: tempDirectoryURL.appendingPathComponent("orphan-directory-registry", isDirectory: true)
+        )
+        let finalURL = tempDirectoryURL.appendingPathComponent("orphan-directory", isDirectory: true)
+        let tx = try DownloadDestinationTransaction.begin(
+            finalURL: finalURL,
+            isDirectory: true,
+            registry: registry
+        )
+        try "PARTIAL".write(
+            to: tx.workingURL.appendingPathComponent("nested.chk"),
+            atomically: true,
+            encoding: .utf8
+        )
+        tx.abandonWithoutCleanup()
+
+        let result = try registry.sweepOrphans()
+
+        XCTAssertEqual(result.reclaimedCount, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: finalURL.path))
+    }
+
+    private func directoryContainsWorkingItem(for finalURL: URL) throws -> Bool {
+        let prefix = ".\(finalURL.lastPathComponent).berth-part-"
+        return try FileManager.default.contentsOfDirectory(atPath: finalURL.deletingLastPathComponent().path)
+            .contains { $0.hasPrefix(prefix) }
     }
 }

--- a/BerthTests/DownloadDestinationTransactionTests.swift
+++ b/BerthTests/DownloadDestinationTransactionTests.swift
@@ -120,9 +120,33 @@ final class DownloadDestinationTransactionTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: finalURL.appendingPathComponent("sub/1.txt").path))
     }
 
-    // MARK: - 6. 目录 final 已存在且非空: 拒绝静默合并, 抛出明确冲突, 保护已有目录
+    // MARK: - 6. 目录 final 已存在 (空目录与非空目录): 均严格拒绝替换并保护原有目录
 
-    func testDirectoryFinalAlreadyExistsAndNonEmptyRefusesMerge() throws {
+    func testExistingEmptyDirectoryRefusesCommitAndPreservesFinal() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("empty_existing_dir")
+        try FileManager.default.createDirectory(at: finalURL, withIntermediateDirectories: true)
+
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: true)
+        try "REMOTE CONTENT".write(to: tx.workingURL.appendingPathComponent("remote.txt"), atomically: true, encoding: .utf8)
+
+        do {
+            try tx.commit()
+            XCTFail("Commit must throw when destination directory already exists")
+        } catch let error as DownloadDestinationTransaction.TransactionError {
+            XCTAssertEqual(error, .destinationDirectoryAlreadyExists(finalURL))
+        }
+
+        // Clean up transaction
+        tx.discard()
+
+        // Existing empty directory must NOT have been removed or merged
+        XCTAssertTrue(FileManager.default.fileExists(atPath: finalURL.path))
+        let remaining = try FileManager.default.contentsOfDirectory(atPath: finalURL.path)
+        XCTAssertTrue(remaining.isEmpty, "Empty directory must remain empty and untouched")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+    }
+
+    func testExistingNonEmptyDirectoryRefusesCommitAndPreservesFinal() throws {
         let finalURL = tempDirectoryURL.appendingPathComponent("existing_folder")
         try FileManager.default.createDirectory(at: finalURL, withIntermediateDirectories: true)
         try "IMPORTANT LOCAL FILE".write(to: finalURL.appendingPathComponent("local.txt"), atomically: true, encoding: .utf8)
@@ -134,7 +158,7 @@ final class DownloadDestinationTransactionTests: XCTestCase {
             try tx.commit()
             XCTFail("Commit must throw when destination directory already exists and is non-empty")
         } catch let error as DownloadDestinationTransaction.TransactionError {
-            XCTAssertEqual(error, .destinationDirectoryNotEmpty(finalURL))
+            XCTAssertEqual(error, .destinationDirectoryAlreadyExists(finalURL))
         }
 
         // Clean up transaction
@@ -163,7 +187,86 @@ final class DownloadDestinationTransactionTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
     }
 
-    // MARK: - 8. 模拟写入失败 (例如 ENOSPC / 网络异常): discard 保留原 final
+    // MARK: - 8. fail-closed: missing working item 必须 throw
+
+    func testMissingWorkingFileFailsClosedAndPreservesFinal() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("existing_safe.bin")
+        let originalBytes = "PRECIOUS PRE-EXISTING DATA".data(using: .utf8)!
+        try originalBytes.write(to: finalURL)
+
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: false)
+
+        // Do NOT create working file
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+
+        do {
+            try tx.commit()
+            XCTFail("Commit must throw when working file was never created")
+        } catch let error as DownloadDestinationTransaction.TransactionError {
+            XCTAssertEqual(error, .workingItemMissing(tx.workingURL))
+        }
+
+        XCTAssertEqual(try Data(contentsOf: finalURL), originalBytes, "Original file must be completely untouched")
+    }
+
+    func testMissingWorkingDirectoryFailsClosed() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("target_dir")
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: true)
+
+        // Remove the pre-created working directory to simulate missing payload
+        try FileManager.default.removeItem(at: tx.workingURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+
+        do {
+            try tx.commit()
+            XCTFail("Commit must throw when working directory is missing")
+        } catch let error as DownloadDestinationTransaction.TransactionError {
+            XCTAssertEqual(error, .workingItemMissing(tx.workingURL))
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: finalURL.path))
+    }
+
+    // MARK: - 9. 真实文件系统 commit 失败: 保护已有 final 不被破坏
+
+    func testCommitFailurePreservesOriginalFinal() throws {
+        let subFolder = tempDirectoryURL.appendingPathComponent("readonly_test_dir", isDirectory: true)
+        try FileManager.default.createDirectory(at: subFolder, withIntermediateDirectories: true)
+
+        let finalURL = subFolder.appendingPathComponent("target.bin")
+        let originalContent = "ORIGINAL UNTOUCHED CONTENT"
+        try originalContent.write(to: finalURL, atomically: true, encoding: .utf8)
+
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: false)
+        try "NEW CONTENT".write(to: tx.workingURL, atomically: true, encoding: .utf8)
+
+        // Make parent directory read-only to provoke a real filesystem failure during replaceItemAt
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: subFolder.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: subFolder.path)
+        }
+
+        var commitError: Error?
+        do {
+            try tx.commit()
+            XCTFail("Commit should fail in read-only directory")
+        } catch {
+            commitError = error
+        }
+
+        XCTAssertNotNil(commitError)
+
+        // Restore permissions and discard working
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: subFolder.path)
+        tx.discard()
+
+        // Original final file must be 100% intact
+        let finalRead = try String(contentsOf: finalURL, encoding: .utf8)
+        XCTAssertEqual(finalRead, originalContent, "Commit failure must leave finalURL completely intact")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+    }
+
+    // MARK: - 10. 模拟写入失败 (ENOSPC-equivalent failure cleanup regression): discard 保留原 final
 
     func testWriteFailurePreservesOriginalFinalAndCleansWorking() throws {
         let finalURL = tempDirectoryURL.appendingPathComponent("protected_existing.bin")
@@ -172,7 +275,7 @@ final class DownloadDestinationTransactionTests: XCTestCase {
 
         let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: false)
 
-        // Write partial before error
+        // Write partial before simulated failure
         try "partial before error".write(to: tx.workingURL, atomically: true, encoding: .utf8)
 
         // Simulate error handling block

--- a/BerthTests/DownloadDestinationTransactionTests.swift
+++ b/BerthTests/DownloadDestinationTransactionTests.swift
@@ -1,0 +1,186 @@
+import XCTest
+@testable import Berth
+
+final class DownloadDestinationTransactionTests: XCTestCase {
+
+    private var tempDirectoryURL: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Berth-TransactionTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectoryURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        if let tempDirectoryURL {
+            try? FileManager.default.removeItem(at: tempDirectoryURL)
+        }
+        try await super.tearDown()
+    }
+
+    // MARK: - 1. 单文件 final 不存在: 取消后 final 不存在, working 不存在
+
+    func testSingleFileFinalDoesNotExistAndCancelDiscardsWorking() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("target_file.bin")
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: false)
+
+        // Working URL must be hidden, unique, and strictly contained in parent
+        XCTAssertTrue(tx.workingURL.lastPathComponent.hasPrefix(".target_file.bin.berth-part-"))
+        XCTAssertEqual(tx.workingURL.deletingLastPathComponent().path, tempDirectoryURL.path)
+
+        // Simulate partial write
+        try "partial chunk".write(to: tx.workingURL, atomically: true, encoding: .utf8)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tx.workingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: finalURL.path))
+
+        // Cancel -> discard
+        tx.discard()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: finalURL.path), "Final must not exist after cancellation")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path), "Working must be removed after cancellation")
+    }
+
+    // MARK: - 2. 单文件 final 已存在: 取消后 final 保持原内容, working 不存在
+
+    func testSingleFileFinalAlreadyExistsAndCancelPreservesOriginalData() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("precious_data.bin")
+        let originalData = "ORIGINAL CRITICAL DATA".data(using: .utf8)!
+        try originalData.write(to: finalURL)
+
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: false)
+
+        // Write partial new data to working
+        let partialData = "NEW PARTIAL DATA".data(using: .utf8)!
+        try partialData.write(to: tx.workingURL)
+
+        // Verify final has NOT been touched or truncated
+        let readBeforeDiscard = try Data(contentsOf: finalURL)
+        XCTAssertEqual(readBeforeDiscard, originalData, "Final must not be truncated during download")
+
+        // Cancel -> discard
+        tx.discard()
+
+        // Verify final still contains original data intact
+        let readAfterDiscard = try Data(contentsOf: finalURL)
+        XCTAssertEqual(readAfterDiscard, originalData, "Final must remain 100% intact after cancellation")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+    }
+
+    // MARK: - 3. 单文件成功: commit 后 working 不存在, final 包含完整新内容
+
+    func testSingleFileSuccessCommitsAtomically() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("final_output.bin")
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: false)
+
+        let completedData = "FULL COMPLETED CONTENT 12345".data(using: .utf8)!
+        try completedData.write(to: tx.workingURL)
+
+        try tx.commit()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path), "Working file must be consumed on commit")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: finalURL.path))
+        let resultData = try Data(contentsOf: finalURL)
+        XCTAssertEqual(resultData, completedData)
+    }
+
+    // MARK: - 4. 单文件覆盖成功: final 原本存在, commit 后原子替换为新内容
+
+    func testSingleFileAtomicReplaceWhenFinalExists() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("replace_target.bin")
+        try "OLD DATA V1".write(to: finalURL, atomically: true, encoding: .utf8)
+
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: false)
+        try "NEW COMPLETED DATA V2".write(to: tx.workingURL, atomically: true, encoding: .utf8)
+
+        try tx.commit()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+        let result = try String(contentsOf: finalURL, encoding: .utf8)
+        XCTAssertEqual(result, "NEW COMPLETED DATA V2")
+    }
+
+    // MARK: - 5. 目录 final 不存在: 递归完整内容成功 commit 为 final
+
+    func testDirectoryFinalDoesNotExistCommitsAtomically() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("my_project")
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: true)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tx.workingURL.path))
+
+        // Create nested files in working
+        let subDir = tx.workingURL.appendingPathComponent("sub", isDirectory: true)
+        try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true)
+        try "file1".write(to: subDir.appendingPathComponent("1.txt"), atomically: true, encoding: .utf8)
+
+        try tx.commit()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: finalURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: finalURL.appendingPathComponent("sub/1.txt").path))
+    }
+
+    // MARK: - 6. 目录 final 已存在且非空: 拒绝静默合并, 抛出明确冲突, 保护已有目录
+
+    func testDirectoryFinalAlreadyExistsAndNonEmptyRefusesMerge() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("existing_folder")
+        try FileManager.default.createDirectory(at: finalURL, withIntermediateDirectories: true)
+        try "IMPORTANT LOCAL FILE".write(to: finalURL.appendingPathComponent("local.txt"), atomically: true, encoding: .utf8)
+
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: true)
+        try "REMOTE NEW FILE".write(to: tx.workingURL.appendingPathComponent("remote.txt"), atomically: true, encoding: .utf8)
+
+        do {
+            try tx.commit()
+            XCTFail("Commit must throw when destination directory already exists and is non-empty")
+        } catch let error as DownloadDestinationTransaction.TransactionError {
+            XCTAssertEqual(error, .destinationDirectoryNotEmpty(finalURL))
+        }
+
+        // Clean up transaction
+        tx.discard()
+
+        // Existing folder must remain completely intact
+        XCTAssertTrue(FileManager.default.fileExists(atPath: finalURL.appendingPathComponent("local.txt").path))
+        let content = try String(contentsOf: finalURL.appendingPathComponent("local.txt"), encoding: .utf8)
+        XCTAssertEqual(content, "IMPORTANT LOCAL FILE")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+    }
+
+    // MARK: - 7. 目录下载取消: working 树被完全删除, final 不存在
+
+    func testDirectoryCancellationCleansWorkingTree() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("cancelled_tree")
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: true)
+
+        let subDir = tx.workingURL.appendingPathComponent("deep/dir", isDirectory: true)
+        try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true)
+        try "data".write(to: subDir.appendingPathComponent("leaf.txt"), atomically: true, encoding: .utf8)
+
+        tx.discard()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: finalURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+    }
+
+    // MARK: - 8. 模拟写入失败 (例如 ENOSPC / 网络异常): discard 保留原 final
+
+    func testWriteFailurePreservesOriginalFinalAndCleansWorking() throws {
+        let finalURL = tempDirectoryURL.appendingPathComponent("protected_existing.bin")
+        let originalBytes = "UNTOUCHED OLD DATA".data(using: .utf8)!
+        try originalBytes.write(to: finalURL)
+
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: false)
+
+        // Write partial before error
+        try "partial before error".write(to: tx.workingURL, atomically: true, encoding: .utf8)
+
+        // Simulate error handling block
+        let simulatedError = POSIXError(.ENOSPC)
+        tx.discard()
+
+        XCTAssertEqual(try Data(contentsOf: finalURL), originalBytes)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+        XCTAssertEqual(simulatedError.code, .ENOSPC)
+    }
+}

--- a/BerthTests/DownloadDestinationTransactionTests.swift
+++ b/BerthTests/DownloadDestinationTransactionTests.swift
@@ -395,6 +395,53 @@ final class DownloadDestinationTransactionTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: finalURL.path))
     }
 
+    // MARK: - 12. 不支持 RENAME_SWAP 的卷(exFAT/SMB/NFS):回落到 rename(2) 仍原子替换并释放登记
+
+    func testReplaceFallsBackToRenameOnVolumeWithoutSwapSupport() throws {
+        let image = tempDirectoryURL.appendingPathComponent("exfat.dmg")
+        let mountPoint = tempDirectoryURL.appendingPathComponent("exfat", isDirectory: true)
+        guard Self.run("/usr/bin/hdiutil", ["create", "-quiet", "-size", "8m", "-fs", "ExFAT", "-volname", "BerthTest", image.path]) == 0,
+              Self.run("/usr/bin/hdiutil", ["attach", "-quiet", "-nobrowse", "-mountpoint", mountPoint.path, image.path]) == 0
+        else {
+            throw XCTSkip("hdiutil cannot create or attach an exFAT image in this environment")
+        }
+        addTeardownBlock {
+            _ = Self.run("/usr/bin/hdiutil", ["detach", "-quiet", "-force", mountPoint.path])
+        }
+
+        let finalURL = mountPoint.appendingPathComponent("replace.bin")
+        try "OLD".write(to: finalURL, atomically: true, encoding: .utf8)
+        let registry = DownloadTransactionRegistry(
+            baseDirectory: tempDirectoryURL.appendingPathComponent("exfat-registry", isDirectory: true)
+        )
+        let tx = try DownloadDestinationTransaction.begin(finalURL: finalURL, isDirectory: false, registry: registry)
+        try "NEW".write(to: tx.workingURL, atomically: true, encoding: .utf8)
+
+        try tx.commit()
+
+        XCTAssertEqual(try String(contentsOf: finalURL, encoding: .utf8), "NEW")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
+        let manifests = try FileManager.default.contentsOfDirectory(atPath: registry.baseDirectory.path)
+            .filter { $0.hasSuffix(".json") }
+        XCTAssertTrue(manifests.isEmpty, "completed transaction must not leave a manifest behind")
+    }
+
+    @discardableResult
+    private static func run(_ executable: String, _ arguments: [String]) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            return -1
+        }
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+
     private func directoryContainsWorkingItem(for finalURL: URL) throws -> Bool {
         let prefix = ".\(finalURL.lastPathComponent).berth-part-"
         return try FileManager.default.contentsOfDirectory(atPath: finalURL.deletingLastPathComponent().path)

--- a/BerthTests/DownloadDestinationTransactionTests.swift
+++ b/BerthTests/DownloadDestinationTransactionTests.swift
@@ -343,27 +343,34 @@ final class DownloadDestinationTransactionTests: XCTestCase {
         tx.discard()
     }
 
-    func testSweepRemovesAbandonedFileTransaction() throws {
+    func testSweepRetainsRecentAbandonedFileUntilGraceExpires() throws {
+        let createdAt = Date()
         let registry = DownloadTransactionRegistry(
-            baseDirectory: tempDirectoryURL.appendingPathComponent("orphan-registry", isDirectory: true)
+            baseDirectory: tempDirectoryURL.appendingPathComponent("orphan-registry", isDirectory: true),
+            orphanGracePeriod: 3600
         )
         let finalURL = tempDirectoryURL.appendingPathComponent("orphan.bin")
         let tx = try DownloadDestinationTransaction.begin(
             finalURL: finalURL,
             isDirectory: false,
+            createdAt: createdAt,
             registry: registry
         )
         try "PARTIAL".write(to: tx.workingURL, atomically: true, encoding: .utf8)
         tx.abandonWithoutCleanup()
 
-        let result = try registry.sweepOrphans()
+        let recentResult = try registry.sweepOrphans(now: createdAt.addingTimeInterval(3599))
+        XCTAssertEqual(recentResult.reclaimedCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tx.workingURL.path))
 
-        XCTAssertEqual(result.reclaimedCount, 1)
+        let expiredResult = try registry.sweepOrphans(now: createdAt.addingTimeInterval(3601))
+        XCTAssertEqual(expiredResult.reclaimedCount, 1)
         XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: finalURL.path))
     }
 
     func testSweepRemovesAbandonedDirectoryTransaction() throws {
+        let now = Date()
         let registry = DownloadTransactionRegistry(
             baseDirectory: tempDirectoryURL.appendingPathComponent("orphan-directory-registry", isDirectory: true)
         )
@@ -371,6 +378,7 @@ final class DownloadDestinationTransactionTests: XCTestCase {
         let tx = try DownloadDestinationTransaction.begin(
             finalURL: finalURL,
             isDirectory: true,
+            createdAt: now.addingTimeInterval(-(DownloadTransactionRegistry.defaultOrphanGracePeriod + 1)),
             registry: registry
         )
         try "PARTIAL".write(
@@ -380,7 +388,7 @@ final class DownloadDestinationTransactionTests: XCTestCase {
         )
         tx.abandonWithoutCleanup()
 
-        let result = try registry.sweepOrphans()
+        let result = try registry.sweepOrphans(now: now)
 
         XCTAssertEqual(result.reclaimedCount, 1)
         XCTAssertFalse(FileManager.default.fileExists(atPath: tx.workingURL.path))

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -903,6 +903,49 @@ final class SFTPBrowserTests: XCTestCase {
 
     // MARK: - Download Cancellation Tests
 
+    func testExistingDestinationDirectoryFailsBeforeStartingRemoteTransfer() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ExistingDestination-\(UUID().uuidString)", isDirectory: true)
+        let finalURL = tempDirectory.appendingPathComponent("remote-project", isDirectory: true)
+        try FileManager.default.createDirectory(at: finalURL, withIntermediateDirectories: true)
+        try "LOCAL".write(
+            to: finalURL.appendingPathComponent("keep.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let browser = SFTPBrowser { throw CocoaError(.fileNoSuchFile) }
+        let transferStarted = expectation(description: "remote transfer must not start")
+        transferStarted.isInverted = true
+        browser.downloadExecutor = { _, _, _, _, _, _, _, _ in
+            transferStarted.fulfill()
+            return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 0)
+        }
+
+        let entry = SFTPBrowser.Entry(
+            name: "remote-project",
+            isDirectory: true,
+            isSymlink: false,
+            size: 0,
+            sizeIsKnown: false,
+            modified: Date()
+        )
+        await browser.download(entry, to: finalURL)
+        await fulfillment(of: [transferStarted], timeout: 0.1)
+
+        XCTAssertEqual(
+            try String(contentsOf: finalURL.appendingPathComponent("keep.txt"), encoding: .utf8),
+            "LOCAL"
+        )
+        XCTAssertTrue(browser.transfers.isEmpty)
+        if case .failed = browser.state {
+            // Expected: the conflict is surfaced without starting any SFTP work.
+        } else {
+            XCTFail("Existing destination directory must fail before transfer")
+        }
+    }
+
     func testSingleDownloadCancellation() async throws {
         let browser = SFTPBrowser {
             throw CocoaError(.fileNoSuchFile)
@@ -952,6 +995,56 @@ final class SFTPBrowserTests: XCTestCase {
         XCTAssertEqual(browser.transfers.count, 0)
         if case .failed = browser.state {
             XCTFail("Browser state must NOT be .failed when user cancels transfer")
+        }
+    }
+
+    func testCancelledExecutorCannotCommitAfterReturningSuccess() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CancelCommitRace-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let finalURL = tempDirectory.appendingPathComponent("result.bin")
+        try Data("ORIGINAL".utf8).write(to: finalURL)
+
+        let browser = SFTPBrowser {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let entry = SFTPBrowser.Entry(
+            name: "result.bin",
+            isDirectory: false,
+            isSymlink: false,
+            size: 8,
+            sizeIsKnown: true,
+            modified: Date()
+        )
+        let workingReady = expectation(description: "working file ready")
+
+        browser.downloadExecutor = { _, _, localURL, _, _, _, _, _ in
+            try Data("NEW DATA".utf8).write(to: localURL)
+            workingReady.fulfill()
+            // 模拟底层在最终 CLOSE 后忽略取消并正常返回；Task cancellation 本身不会强制 throw。
+            while !Task.isCancelled {
+                await Task.yield()
+            }
+            return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 8)
+        }
+
+        let downloadTask = Task {
+            await browser.download(entry, to: finalURL)
+        }
+        await fulfillment(of: [workingReady], timeout: 2.0)
+        let transfer = try XCTUnwrap(browser.transfers.first)
+
+        browser.cancelTransfer(transfer.id)
+        await downloadTask.value
+
+        XCTAssertEqual(try Data(contentsOf: finalURL), Data("ORIGINAL".utf8))
+        let leftovers = try FileManager.default.contentsOfDirectory(atPath: tempDirectory.path)
+            .filter { $0.contains(".berth-part-") }
+        XCTAssertTrue(leftovers.isEmpty)
+        if case .failed = browser.state {
+            XCTFail("A cancelled commit race must not put the browser in failed state")
         }
     }
 

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -956,6 +956,13 @@ final class SFTPBrowserTests: XCTestCase {
     }
 
     func testMultiDownloadIndependentCancellation() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MultiCancel-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let urlA = tempDir.appendingPathComponent("fileA.bin")
+        let urlB = tempDir.appendingPathComponent("fileB.bin")
+
         let browser = SFTPBrowser {
             throw CocoaError(.fileNoSuchFile)
         }
@@ -971,6 +978,7 @@ final class SFTPBrowserTests: XCTestCase {
             if request.entry.name == "fileA.bin" {
                 startedA.fulfill()
                 try await Task.sleep(for: .milliseconds(300))
+                try Data("FILE A DATA".utf8).write(to: localURL)
                 completedA.fulfill()
                 return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 100)
             } else {
@@ -985,8 +993,8 @@ final class SFTPBrowserTests: XCTestCase {
             }
         }
 
-        let taskA = Task { await browser.download(entryA, to: URL(fileURLWithPath: "/tmp/a")) }
-        let taskB = Task { await browser.download(entryB, to: URL(fileURLWithPath: "/tmp/b")) }
+        let taskA = Task { await browser.download(entryA, to: urlA) }
+        let taskB = Task { await browser.download(entryB, to: urlB) }
 
         await fulfillment(of: [startedA, startedB], timeout: 2.0)
         XCTAssertEqual(browser.transfers.count, 2)
@@ -1004,6 +1012,8 @@ final class SFTPBrowserTests: XCTestCase {
         if case .failed = browser.state {
             XCTFail("Neither cancelled B nor completed A should put browser in failed state")
         }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: urlA.path), "Completed transfer A must commit to final URL")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: urlB.path), "Cancelled transfer B must not leave file at final URL")
     }
 
     func testCancellationPropagationFromOuterTask() async throws {

--- a/BerthTests/SFTPBrowserTests.swift
+++ b/BerthTests/SFTPBrowserTests.swift
@@ -918,7 +918,7 @@ final class SFTPBrowserTests: XCTestCase {
         let browser = SFTPBrowser { throw CocoaError(.fileNoSuchFile) }
         let transferStarted = expectation(description: "remote transfer must not start")
         transferStarted.isInverted = true
-        browser.downloadExecutor = { _, _, _, _, _, _, _, _ in
+        browser.downloadExecutor = { _ in
             transferStarted.fulfill()
             return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 0)
         }
@@ -1020,8 +1020,8 @@ final class SFTPBrowserTests: XCTestCase {
         )
         let workingReady = expectation(description: "working file ready")
 
-        browser.downloadExecutor = { _, _, localURL, _, _, _, _, _ in
-            try Data("NEW DATA".utf8).write(to: localURL)
+        browser.downloadExecutor = { request in
+            try Data("NEW DATA".utf8).write(to: request.localURL)
             workingReady.fulfill()
             // 模拟底层在最终 CLOSE 后忽略取消并正常返回；Task cancellation 本身不会强制 throw。
             while !Task.isCancelled {
@@ -1071,7 +1071,7 @@ final class SFTPBrowserTests: XCTestCase {
             if request.entry.name == "fileA.bin" {
                 startedA.fulfill()
                 try await Task.sleep(for: .milliseconds(300))
-                try Data("FILE A DATA".utf8).write(to: localURL)
+                try Data("FILE A DATA".utf8).write(to: request.localURL)
                 completedA.fulfill()
                 return SFTPDownloadEngine.SFTPDownloadResult(copiedBytes: 100)
             } else {

--- a/project.yml
+++ b/project.yml
@@ -100,6 +100,7 @@ targets:
       - path: Berth/Core/SSH/PortForwardService.swift
       - path: Berth/Core/SSH/ProxyConnector.swift
       - path: Berth/Core/SSH/SOCKS5.swift
+      - path: Berth/Core/SSH/DownloadDestinationTransaction.swift
       - path: Berth/Core/SSH/SFTPBrowser.swift
       - path: Berth/Core/SSH/SFTPDownloadEngine.swift
       - path: Berth/Core/SSH/SFTPDragRetentionPolicy.swift


### PR DESCRIPTION
## 概述

完善 SFTP 面板“下载…”写入本地目标时的事务语义。下载过程不再直接修改最终目标，而是先写入同一父目录中的唯一隐藏工作路径；只有远端传输完整成功且任务仍未取消时，才以原子操作提交结果。

这可以避免断网、取消、应用退出或底层传输失败后留下看似完整的半截文件，也不会在新内容下载完成前破坏已有同名文件。

## 主要变更

- 新增 `DownloadDestinationTransaction`，在最终目标同一目录创建 `.文件名.berth-part-<UUID>` 工作项。
- 最终目标不存在时，下载完成后以原子 rename 提交。
- 已有同名普通文件时，仅在新文件完整下载后通过 `renameatx_np(RENAME_SWAP)` 原子替换；失败或取消始终保留原文件。
- 已有同名目录，或目录下载目标已被占用时，在远端传输开始前直接拒绝，不执行隐式目录合并。
- 在目标准备、传输完成和最终提交前后检查任务取消状态，防止底层忽略取消并返回成功后仍误提交。
- 下载开始前冻结所选远端目录；传输期间切换 SFTP 面板位置不会把任务重定向到新的同名文件。
- 使用持久化 manifest 与 `flock` 保护活跃事务；应用崩溃后保留登记，并经过一小时宽限期再回收经过严格路径验证的工作项。
- 外置磁盘或网络卷暂时离线时保留登记，等待后续启动重试，不把无法确认的路径当作可删除对象。
- 将目标准备、提交和递归清理放入后台 actor，避免大型目录清理阻塞界面。
- 增加本地化错误信息，并在应用启动时扫描遗留事务。
- 将事务源文件加入 BerthiOS target，保持共享 `SFTPBrowser` 的源文件依赖完整。

## 同名目标行为

- 文件 → 不存在：成功后原子移动到最终位置。
- 文件 → 已有普通文件：成功后原子替换；失败或取消保留旧文件。
- 文件 → 已有目录：预检失败。
- 目录 → 目标已存在：预检失败，不覆盖也不合并。
- 多个并行任务：各自使用独立 UUID 工作路径，互不覆盖。

## 验证

- `xcodegen generate`
- macOS 完整测试套件中，除需要签名 Keychain entitlement 的既有 `KeychainStoreTests` 外，262/262 个 XCTest 通过。
- 额外 1 个 Swift Testing 测试通过。
- 无签名本机运行 `KeychainStoreTests` 会返回 `-34018`，与本 PR 的 SFTP 修改无关。
- 未进行 iOS 运行测试；已通过生成工程确认事务源文件同时进入 macOS 与 BerthiOS Sources build phase。

## 依赖

前置的 SFTP pipeline 与拖拽 staging 生命周期改动已经分别通过 PR #25 和 PR #26 合并到主线。