### PR TITLE
Touch ID 门禁按运行期授权:同主机重连、新建连接不再重复验证,空闲 15 分钟失效(#29)

### DIFF
--- a/Berth/Core/SSH/KeyUseGrants.swift
+++ b/Berth/Core/SSH/KeyUseGrants.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// issue #29:私钥门禁(Touch ID)不再每次拨号都弹。同一主机 + 同一套认证材料在本次运行内
+/// 过一次门禁就登记授权,之后的断线重连、自动重连、右键「新建独立连接」直接放行。
+/// 授权空闲 15 分钟失效 —— 空闲指既没有存活会话在用它,也没再过门禁;有会话连着就一直有效,
+/// 断开那一刻重新起算。换密钥文件/密钥库条目/跳板机/用户名等认证材料变了要重新验证。
+/// 只存内存,退出 Berth 即清空。仪表盘后台监控的授权(`ServerMonitor.authorizeKeyUse`)独立于此。
+@MainActor
+final class KeyUseGrants {
+    static let shared = KeyUseGrants()
+
+    /// 空闲多久后需要重新验证
+    static let idleTimeout: TimeInterval = 15 * 60
+
+    private struct Grant {
+        var lastUsed: Date
+        /// 正在用这份授权的存活会话数;>0 时授权不会因空闲失效
+        var liveSessions = 0
+    }
+
+    private var grants: [String: Grant] = [:]
+    private let now: @MainActor () -> Date
+    private let isGateEnabled: @MainActor () -> Bool
+
+    init(
+        now: @escaping @MainActor () -> Date = { Date() },
+        isGateEnabled: @escaping @MainActor () -> Bool = {
+            UserDefaults.standard.object(forKey: SettingsKeys.requireTouchIDForKeys) as? Bool ?? true
+        }
+    ) {
+        self.now = now
+        self.isGateEnabled = isGateEnabled
+    }
+
+    /// 拨号前调用:有效授权直接放行并续期;否则跑一次 `gate`(Touch ID),成功后登记。
+    /// 门禁设置关着时既不弹也不登记 —— 之后打开设置,下一次连接就得验证。
+    func authorize(_ spec: HostSpec, gate: () async throws -> Void) async throws {
+        guard isGateEnabled() else { return }
+        let key = Self.key(for: spec)
+        if var grant = grants[key],
+           grant.liveSessions > 0 || now().timeIntervalSince(grant.lastUsed) < Self.idleTimeout {
+            grant.lastUsed = now()
+            grants[key] = grant
+            DebugLog.append("key-use grant reused host=\(spec.hostname):\(spec.port) live=\(grant.liveSessions)")
+            return
+        }
+        try await gate()
+        grants[key] = Grant(lastUsed: now(), liveSessions: grants[key]?.liveSessions ?? 0)
+        DebugLog.append("key-use grant recorded host=\(spec.hostname):\(spec.port)")
+    }
+
+    /// 会话连上了:存活期间授权不失效。返回 false 表示这台主机没有授权记录
+    /// (密码主机、或连接时门禁关着),调用方不必再报断开。
+    @discardableResult
+    func sessionConnected(_ spec: HostSpec) -> Bool {
+        let key = Self.key(for: spec)
+        guard var grant = grants[key] else { return false }
+        grant.liveSessions += 1
+        grant.lastUsed = now()
+        grants[key] = grant
+        return true
+    }
+
+    /// 会话断开:从这一刻起算空闲
+    func sessionDisconnected(_ spec: HostSpec) {
+        let key = Self.key(for: spec)
+        guard var grant = grants[key] else { return }
+        grant.liveSessions = max(0, grant.liveSessions - 1)
+        grant.lastUsed = now()
+        grants[key] = grant
+    }
+
+    /// 授权键:主机 + 链路上每一跳的认证材料
+    static func key(for spec: HostSpec) -> String {
+        ([spec] + spec.jump).map { hop in
+            [
+                hop.hostID.uuidString, hop.username, hop.hostname, String(hop.port),
+                hop.authMethod.rawValue, hop.privateKeyPath ?? "", hop.keyID?.uuidString ?? "",
+            ].joined(separator: "|")
+        }.joined(separator: ">")
+    }
+}

--- a/Berth/Core/SSH/TerminalSession.swift
+++ b/Berth/Core/SSH/TerminalSession.swift
@@ -106,6 +106,8 @@ final class TerminalSession: Identifiable {
     @ObservationIgnored private var willBorrow: SSHConnection?
     /// 本次运行是否走了借用路径(借用会话不自动重连,避免网络抖动时多会话各自新建 TCP 造成连接风暴)
     @ObservationIgnored private var isBorrower = false
+    /// 本会话连上时在 KeyUseGrants 登记为「存活会话」了(断开时要注销)
+    @ObservationIgnored private var holdsKeyUseGrant = false
     @ObservationIgnored private var forwardService: PortForwardService?
     @ObservationIgnored private var sessionTask: Task<Void, Never>?
     @ObservationIgnored private var stdinWriter: AsyncStream<StdinEvent>.Continuation?
@@ -235,6 +237,11 @@ final class TerminalSession: Identifiable {
                 disconnectReason = .error(message)
             }
             state = .disconnected(disconnectReason)
+            // 门禁授权从断开这一刻起算空闲(服务器重启后 15 分钟内重连不必再过 Touch ID)
+            if holdsKeyUseGrant {
+                holdsKeyUseGrant = false
+                KeyUseGrants.shared.sessionDisconnected(spec)
+            }
             // 会话结束时质询弹窗必须收掉:服务器可能在用户找手机输 MFA 码时超时断开
             //(LoginGraceTime),不收的话 sheet 悬在死管道上,提交毫无反应
             resolveKeyboardInteractivePrompt(answers: nil)
@@ -914,10 +921,15 @@ final class TerminalSession: Identifiable {
                 await self?.requestKeyboardInteractiveAnswers(challenge)
             },
             keyGate: { [weak self] in
-                try await SSHDialer.touchIDGate(
-                    reason: String(localized: "使用私钥连接 \(self?.spec.label ?? "")"),
-                    onProgress: { detail in self?.state = .connecting(detail: detail) }
-                )
+                guard let self else { return }
+                // issue #29:同一主机本次运行内过一次门禁即可,重连/新建独立连接不再弹;
+                // 空闲 15 分钟或换了认证材料才重新验证(KeyUseGrants)
+                try await KeyUseGrants.shared.authorize(self.spec) {
+                    try await SSHDialer.touchIDGate(
+                        reason: String(localized: "使用私钥连接 \(self.spec.label)"),
+                        onProgress: { detail in self.state = .connecting(detail: detail) }
+                    )
+                }
             }
         )
     }
@@ -974,6 +986,7 @@ final class TerminalSession: Identifiable {
                 self.stdinWriter = continuation
                 self.syncTerminalSize()
                 self.state = .connected
+                self.holdsKeyUseGrant = KeyUseGrants.shared.sessionConnected(self.spec)
                 self.connectedAt = Date()
                 self.everConnected = true
                 self.reconnectAttempt = 0

--- a/Berth/Features/Settings/SettingsView.swift
+++ b/Berth/Features/Settings/SettingsView.swift
@@ -329,6 +329,8 @@ struct SettingsView: View {
     private var securityPage: some View {
             Section {
                 Toggle("使用私钥连接前要求 Touch ID / 密码验证", isOn: $requireTouchID)
+                Text("同一主机本次运行内验证一次即可;空闲 15 分钟或更换密钥、跳板机后再次验证。")
+                    .font(.caption).foregroundStyle(.secondary)
                 Toggle("粘贴保护:多行或危险命令先确认", isOn: $pasteProtection)
             }
     }

--- a/Berth/Resources/Localizable.xcstrings
+++ b/Berth/Resources/Localizable.xcstrings
@@ -3026,6 +3026,16 @@
         }
       }
     },
+    "同一主机本次运行内验证一次即可;空闲 15 分钟或更换密钥、跳板机后再次验证。": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "One verification per host per launch is enough; verify again after 15 idle minutes or when the key or jump host changes."
+          }
+        }
+      }
+    },
     "同步与数据": {
       "localizations": {
         "en": {

--- a/BerthTests/KeyUseGrantsTests.swift
+++ b/BerthTests/KeyUseGrantsTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+@testable import Berth
+
+@MainActor
+final class KeyUseGrantsTests: XCTestCase {
+    private var clock = Date(timeIntervalSince1970: 1_000_000)
+    private var gateEnabled = true
+
+    private func makeGrants() -> KeyUseGrants {
+        KeyUseGrants(now: { [unowned self] in self.clock }, isGateEnabled: { [unowned self] in self.gateEnabled })
+    }
+
+    private func spec(
+        hostID: UUID = UUID(),
+        username: String = "dev",
+        keyPath: String? = "~/.ssh/id_ed25519",
+        jump: [HostSpec] = []
+    ) -> HostSpec {
+        HostSpec(
+            hostID: hostID, label: "a", hostname: "a.example", port: 22, username: username,
+            authMethod: .privateKeyFile, privateKeyPath: keyPath, jump: jump
+        )
+    }
+
+    struct GateDenied: Error {}
+
+    /// 跑一次 authorize,返回 gate(Touch ID)被调用的次数
+    private func gateCalls(_ grants: KeyUseGrants, _ spec: HostSpec, deny: Bool = false) async throws -> Int {
+        var calls = 0
+        try await grants.authorize(spec) {
+            calls += 1
+            if deny { throw GateDenied() }
+        }
+        return calls
+    }
+
+    func testReconnectWithinTimeoutSkipsGate() async throws {
+        let grants = makeGrants()
+        let host = spec()
+        let first = try await gateCalls(grants, host)
+        XCTAssertEqual(first, 1)
+        clock += 14 * 60
+        let second = try await gateCalls(grants, host)
+        XCTAssertEqual(second, 0)
+    }
+
+    func testIdleTimeoutRequiresGateAgain() async throws {
+        let grants = makeGrants()
+        let host = spec()
+        _ = try await gateCalls(grants, host)
+        clock += KeyUseGrants.idleTimeout + 1
+        let again = try await gateCalls(grants, host)
+        XCTAssertEqual(again, 1)
+    }
+
+    func testEachUseRefreshesIdleClock() async throws {
+        let grants = makeGrants()
+        let host = spec()
+        _ = try await gateCalls(grants, host)
+        for _ in 0..<3 {
+            clock += 10 * 60
+            let calls = try await gateCalls(grants, host)
+            XCTAssertEqual(calls, 0, "use within the timeout must keep the grant alive")
+        }
+    }
+
+    func testLiveSessionKeepsGrantAliveAndDisconnectRestartsIdle() async throws {
+        let grants = makeGrants()
+        let host = spec()
+        _ = try await gateCalls(grants, host)
+        XCTAssertTrue(grants.sessionConnected(host))
+
+        // 会话连着 2 小时:右键新建独立连接不弹
+        clock += 2 * 60 * 60
+        let whileLive = try await gateCalls(grants, host)
+        XCTAssertEqual(whileLive, 0)
+
+        // 服务器重启把会话掐断:14 分钟内重连不弹(这次放行也会续期),之后再闲满 15 分钟才弹
+        grants.sessionDisconnected(host)
+        clock += 14 * 60
+        let soonAfter = try await gateCalls(grants, host)
+        XCTAssertEqual(soonAfter, 0)
+        clock += KeyUseGrants.idleTimeout + 1
+        let muchLater = try await gateCalls(grants, host)
+        XCTAssertEqual(muchLater, 1)
+    }
+
+    func testChangedCredentialMaterialPromptsAgain() async throws {
+        let grants = makeGrants()
+        let id = UUID()
+        _ = try await gateCalls(grants, spec(hostID: id))
+
+        let otherKey = try await gateCalls(grants, spec(hostID: id, keyPath: "~/.ssh/id_rsa"))
+        XCTAssertEqual(otherKey, 1, "different IdentityFile must re-verify")
+        let viaJump = try await gateCalls(grants, spec(hostID: id, jump: [spec()]))
+        XCTAssertEqual(viaJump, 1, "added jump host must re-verify")
+        let otherUser = try await gateCalls(grants, spec(hostID: id, username: "root"))
+        XCTAssertEqual(otherUser, 1, "different user must re-verify")
+        let otherHost = try await gateCalls(grants, spec())
+        XCTAssertEqual(otherHost, 1, "another host must re-verify")
+
+        // 原来那套材料的授权仍然有效
+        let original = try await gateCalls(grants, spec(hostID: id))
+        XCTAssertEqual(original, 0)
+    }
+
+    func testFailedGateLeavesNoGrant() async throws {
+        let grants = makeGrants()
+        let host = spec()
+        do {
+            _ = try await gateCalls(grants, host, deny: true)
+            XCTFail("denied gate must throw")
+        } catch is GateDenied {}
+        let retry = try await gateCalls(grants, host)
+        XCTAssertEqual(retry, 1)
+    }
+
+    func testDisabledGateNeitherPromptsNorRecords() async throws {
+        let grants = makeGrants()
+        let host = spec()
+        gateEnabled = false
+        let off = try await gateCalls(grants, host)
+        XCTAssertEqual(off, 0)
+        XCTAssertFalse(grants.sessionConnected(host), "no grant is recorded while the gate is off")
+        gateEnabled = true
+        let on = try await gateCalls(grants, host)
+        XCTAssertEqual(on, 1, "turning the gate on must verify on the next connection")
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,9 @@ BERTH_M1_AUTOTEST=1 BERTH_TRANSIENT_STORE=1 \
   密钥类型按「变更」级警告,证书形式主机密钥一律拒绝;认证失败不自动重连、仪表盘不重试;
   AI 自动执行只放行 `AICommandPolicy` 白名单里的只读命令,命令输出落盘/送模型前过
   `SecretRedactor`;远端命名的文件不交给 LaunchServices 默认程序(本地编辑固定用文本编辑器),
-  `LSFileQuarantineEnabled` 已开;终端不回应 OSC 52 读剪贴板,链接只放行 http/https/mailto(+Mac file)
+  `LSFileQuarantineEnabled` 已开;终端不回应 OSC 52 读剪贴板,链接只放行 http/https/mailto(+Mac file);
+  私钥门禁(Touch ID)按「本次运行 + 主机 + 认证材料」记一次(`KeyUseGrants`,issue #29):存活会话
+  期间不失效,断开后空闲 15 分钟失效,换密钥/跳板机重验,退出即清;仪表盘的后台授权独立
 - 发布形态:Developer ID 签名 + 公证 DMG,不走 App Store(沙盒限制 ~/.ssh 读取)
 - 本地化:zh-Hans 基准 + en,`Berth/Resources/Localizable.xcstrings`。新增 UI 文案后:构建 →
   从 DerivedData 的 `Berth.build/**/*.stringsdata` 汇总 key → 给缺失 key 补 en 翻译(SwiftUI


### PR DESCRIPTION
## 概述

按 #29 的提议改私钥门禁:同一主机本次运行内过一次 Touch ID 即可,重连、自动重连、右键「新建独立连接」不再弹;空闲 15 分钟失效;换密钥 / 跳板机等认证材料后重新验证;退出 Berth 即清空。

## 实现

- 新增 `Core/SSH/KeyUseGrants.swift`(仅 Mac,`@MainActor` 内存态):
  - 授权键 = 主机 id + 链路上每一跳的(用户名、主机、端口、认证方式、密钥文件路径、密钥库 id),任一项变了就是另一把钥匙。
  - `authorize(spec, gate:)`:有效授权直接放行并续期;否则跑一次 Touch ID,成功后登记;门禁设置关着时不弹也不登记(之后打开设置,下一次连接就得验证)。
  - 有存活会话在用的授权不会因空闲失效;`sessionDisconnected` 从断开那一刻起算空闲。所以会话连着几小时后右键新建独立连接不弹,服务器重启掐断后 15 分钟内重连也不弹。
- `TerminalSession`:`keyGate` 改走 `KeyUseGrants.authorize`;连上 / 断开时登记、注销存活会话。借用连接(⌘T/分屏)的会话同样计数。
- 设置页 Touch ID 开关下加一行说明(含 en 文案);CLAUDE.md 安全边界补一条。
- 仪表盘后台监控的「授权一次」机制没动,仍独立。

## 与 #27 的关系

#27 之后自动重连时 Touch ID 弹窗超时 / 取消会被归为认证失败并停止重试,人不在电脑前服务器一重启会话就彻底断了。有了运行期授权,自动重连不再需要弹窗。

## 安全边界

门禁本来就是进程内的 UserDefaults 开关(私钥在可同步的 Keychain 里,没挂生物识别 ACL),防的是「有人坐到解锁的 Mac 前发起连接」。现在已授权主机在 Berth 未退出且 15 分钟内可免验证重连,和仪表盘现有的「本次运行授权一次」同一档。官网「Touch ID guards every private-key use」的表述需要另行调整。

## 验证

- macOS 单测 282 项通过(`KeychainStoreTests` 命令行未签名 -34018 为既有噪音);新增 `KeyUseGrantsTests` 7 项:15 分钟内免验、超时重验、每次使用续期、存活会话保活 + 断开起算空闲、换密钥 / 跳板机 / 用户名 / 主机重验、门禁失败不登记、设置关闭不登记。
- 未做真机 Touch ID 交互冒烟(验收 harness 会关掉门禁),需要手动点一遍:连 → 断 → 重连不弹;右键新建独立连接不弹;编辑主机换密钥后重连弹。
- iOS 不受影响(`KeyUseGrants`、`TerminalSession` 都不在 BerthiOS target)。
