### PR TITLE
修复终端标签与侧栏主机选择不同步

### DIFF
--- a/Berth/Core/Services/SessionManager.swift
+++ b/Berth/Core/Services/SessionManager.swift
@@ -15,7 +15,12 @@ final class SessionManager {
     private(set) var sessions: [TerminalSession] = []
     /// 标签页(每个是一棵分屏树)
     private(set) var tabs: [PaneTab] = []
-    var selectedTabID: PaneTab.ID?
+    var selectedTabID: PaneTab.ID? {
+        didSet { syncSelectedHostID() }
+    }
+    /// 侧栏高亮与当前标签共享的主机选择。侧栏键盘导航也写回这里；
+    /// 标签、分屏焦点变化则由 syncSelectedHostID() 覆盖成当前会话的主机。
+    var selectedHostID: UUID?
 
     /// 有活跃连接的 pane 请求关闭时置此值,UI 弹确认框
     var pendingCloseSession: TerminalSession?
@@ -96,6 +101,14 @@ final class SessionManager {
     var selected: TerminalSession? {
         guard let focused = selectedTab?.focusedID else { return nil }
         return sessions.first { $0.id == focused }
+    }
+
+    private func syncSelectedHostID() {
+        guard let selected, !selected.spec.isLocal else {
+            selectedHostID = nil
+            return
+        }
+        selectedHostID = selected.spec.hostID
     }
 
     /// 兼容旧调用:selectedID = 当前标签聚焦的会话 id
@@ -208,6 +221,7 @@ final class SessionManager {
         sessions.append(secondary)
         tab.root = tab.root.splitting(leaf: current.id, into: secondary.id, axis: axis, branchID: UUID())
         tab.focusedID = secondary.id
+        syncSelectedHostID()
         secondary.connect()
     }
 
@@ -217,8 +231,9 @@ final class SessionManager {
         // 主动去某个 pane = 要看终端,顺手从仪表盘退出来
         isDashboardVisible = false
         let switchedTab = selectedTabID != tab.id
-        selectedTabID = tab.id
         tab.focusedID = sessionID
+        selectedTabID = tab.id
+        syncSelectedHostID()
         if switchedTab {
             isSFTPVisible = false
             isInspectorVisible = false
@@ -273,6 +288,7 @@ final class SessionManager {
         } else {
             removeTabSelectingNeighbor(tab)
         }
+        syncSelectedHostID()
         afterClose()
     }
 
@@ -456,6 +472,7 @@ final class SessionManager {
         guard let tab = tabs.last, tab.root.leafIDs() == [first.id] else { return }
         buildSplits(node, existingLeaf: first.id, in: tab, hosts: hosts)
         tab.focusedID = first.id
+        syncSelectedHostID()
     }
 
     private func firstResolvableHost(_ node: WorkspaceLayout.Node, hosts: [Host]) -> Host? {

--- a/Berth/Features/Sidebar/SidebarView.swift
+++ b/Berth/Features/Sidebar/SidebarView.swift
@@ -21,8 +21,6 @@ struct SidebarView: View {
 
     @AppStorage(SettingsKeys.translucentChrome) private var translucentChrome = true
     @State private var searchText = ""
-    /// 键盘/单击选中的主机行
-    @State private var selectedHostID: UUID?
     /// 主题配色面板(popover)
     @State private var isThemePanelPresented = false
     /// 底部「更多」弹窗(仪表盘/配色/设置)
@@ -184,8 +182,9 @@ struct SidebarView: View {
         .padding(.top, 8)
         .padding(.bottom, 8)
         .onChange(of: searchText) { _, _ in
-            if let selected = selectedHostID, !visibleHosts.contains(where: { $0.id == selected }) {
-                selectedHostID = visibleHosts.first?.id
+            if let selected = sessionManager.selectedHostID,
+               !visibleHosts.contains(where: { $0.id == selected }) {
+                sessionManager.selectedHostID = visibleHosts.first?.id
             }
         }
     }
@@ -307,7 +306,7 @@ struct SidebarView: View {
                     ForEach(hosts) { host in
                         HostRow(
                             host: host,
-                            isSelected: selectedHostID == host.id,
+                            isSelected: sessionManager.selectedHostID == host.id,
                             theme: theme
                         )
                         // 按下即选中(AppKit 层,无手势判定延迟);⌘ 点按再开一条同主机
@@ -546,7 +545,7 @@ struct SidebarView: View {
     /// 单击行 = 切到这台主机:已经开着就切过去,没开才拨号。
     /// (否则单击连接会让在侧栏上下点几下就攒出一堆同主机标签)
     private func activate(_ host: Host) {
-        selectedHostID = host.id
+        sessionManager.selectedHostID = host.id
         if let existing = sessionManager.sessions.first(where: { $0.spec.hostID == host.id }) {
             sessionManager.focusPane(existing.id)
             return
@@ -559,14 +558,14 @@ struct SidebarView: View {
     /// 断网后的假活连接(state 还是 connected)借来也只会失败且不自动重连。
     /// 想复用连接开新 PTY 用 ⌘T(复制当前连接)。
     private func connect(_ host: Host) {
-        selectedHostID = host.id
+        sessionManager.selectedHostID = host.id
         host.lastConnectedAt = Date()
         sessionManager.open(spec: HostSpec.resolve(host, in: allHosts))
     }
 
     /// issue #11:在当前聚焦 pane 旁分屏连接该主机
     private func splitConnect(_ host: Host, axis: SplitAxis) {
-        selectedHostID = host.id
+        sessionManager.selectedHostID = host.id
         host.lastConnectedAt = Date()
         sessionManager.splitFocused(axis: axis, spec: HostSpec.resolve(host, in: allHosts))
     }
@@ -605,7 +604,8 @@ struct SidebarView: View {
     /// 回车:有选中连选中,否则连第一个可见结果(搜索场景)
     private func connectSelectionOrFirst() {
         let rows = displayedHosts
-        if let selected = selectedHostID, let host = rows.first(where: { $0.id == selected }) {
+        if let selected = sessionManager.selectedHostID,
+           let host = rows.first(where: { $0.id == selected }) {
             activate(host)
         } else if !searchText.isEmpty, let first = rows.first {
             activate(first)
@@ -615,16 +615,17 @@ struct SidebarView: View {
     private func moveSelection(_ delta: Int) {
         let rows = displayedHosts
         guard !rows.isEmpty else { return }
-        guard let current = selectedHostID, let index = rows.firstIndex(where: { $0.id == current }) else {
-            selectedHostID = delta > 0 ? rows.first?.id : rows.last?.id
+        guard let current = sessionManager.selectedHostID,
+              let index = rows.firstIndex(where: { $0.id == current }) else {
+            sessionManager.selectedHostID = delta > 0 ? rows.first?.id : rows.last?.id
             return
         }
         let next = min(max(index + delta, 0), rows.count - 1)
-        selectedHostID = rows[next].id
+        sessionManager.selectedHostID = rows[next].id
     }
 
     private func requestDeleteSelection() {
-        guard let selected = selectedHostID,
+        guard let selected = sessionManager.selectedHostID,
               let host = displayedHosts.first(where: { $0.id == selected }) else { return }
         if host.source == .sshConfig {
             configHostPendingDeletion = PendingHost(id: host.id, label: host.label)

--- a/BerthTests/SessionSelectionTests.swift
+++ b/BerthTests/SessionSelectionTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import Berth
+
+@MainActor
+final class SessionSelectionTests: XCTestCase {
+    func testSelectingTerminalTabSynchronizesSidebarHostSelection() throws {
+        let manager = SessionManager()
+        let firstHostID = UUID()
+        let secondHostID = UUID()
+
+        manager.open(spec: spec(hostID: firstHostID, label: "first"), autoConnect: false)
+        let firstTabID = try XCTUnwrap(manager.selectedTabID)
+
+        manager.open(spec: spec(hostID: secondHostID, label: "second"), autoConnect: false)
+        XCTAssertEqual(manager.selectedHostID, secondHostID)
+
+        manager.selectTab(firstTabID)
+
+        XCTAssertEqual(manager.selectedHostID, firstHostID)
+    }
+
+    func testFocusingSessionSynchronizesBothTabAndSidebarSelection() {
+        let manager = SessionManager()
+        let firstHostID = UUID()
+        let firstSession = manager.open(
+            spec: spec(hostID: firstHostID, label: "first"),
+            autoConnect: false
+        )
+        manager.open(spec: spec(hostID: UUID(), label: "second"), autoConnect: false)
+
+        manager.focusPane(firstSession.id)
+
+        XCTAssertEqual(manager.selected?.id, firstSession.id)
+        XCTAssertEqual(manager.selectedHostID, firstHostID)
+    }
+
+    func testClosingSelectedTabSynchronizesSidebarToNeighbor() throws {
+        let manager = SessionManager()
+        let firstHostID = UUID()
+
+        manager.open(spec: spec(hostID: firstHostID, label: "first"), autoConnect: false)
+        manager.open(spec: spec(hostID: UUID(), label: "second"), autoConnect: false)
+        let selectedTab = try XCTUnwrap(manager.selectedTab)
+
+        manager.closeTab(selectedTab)
+
+        XCTAssertEqual(manager.selectedHostID, firstHostID)
+    }
+
+    func testSelectingLocalShellClearsSidebarHostSelection() {
+        let manager = SessionManager()
+        manager.open(spec: spec(hostID: UUID(), label: "remote"), autoConnect: false)
+
+        manager.open(spec: .localShell(), autoConnect: false)
+
+        XCTAssertNil(manager.selectedHostID)
+    }
+
+    private func spec(hostID: UUID, label: String) -> HostSpec {
+        HostSpec(
+            hostID: hostID,
+            label: label,
+            hostname: "\(label).example",
+            port: 22,
+            username: "dev",
+            authMethod: .password,
+            privateKeyPath: nil
+        )
+    }
+}


### PR DESCRIPTION
## 问题

在 macOS 主窗口中，点击侧栏主机可以切换到对应的终端标签；但直接点击顶部终端标签时，侧栏仍保留旧主机的选中状态，导致两处显示不一致。如图：
<img width="2490" height="1366" alt="Screenshot 2026-09-11 at 07-52-35" src="https://github.com/user-attachments/assets/269c9c3a-d009-4c6e-b3c3-19351ee2bc7b" />


## 修复

- 将侧栏选中的主机 ID 提升到 SessionManager，作为标签与侧栏共享的可观察状态
- 在标签切换、分屏焦点切换、关闭标签或分屏和工作空间恢复时同步当前主机
- 侧栏直接读写共享选择状态
- 切换到本地 Shell 时清空远端主机选择

## 测试

新增 SessionSelectionTests，覆盖：

- 点击终端标签后同步侧栏主机
- 聚焦会话后同时同步标签与侧栏
- 关闭当前标签后同步到相邻标签主机
- 选择本地 Shell 时清空侧栏主机选择

SessionSelectionTests 共 4 项，全部通过。